### PR TITLE
Setting(project): axios, tanstack query 세팅

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.3",
+    "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/apps/client/src/shared/apis/axiosInstance.ts
+++ b/apps/client/src/shared/apis/axiosInstance.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const apiRequest = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiRequest;

--- a/apps/client/src/shared/apis/query/getQueryClient.ts
+++ b/apps/client/src/shared/apis/query/getQueryClient.ts
@@ -1,0 +1,19 @@
+import { QueryClient } from "@tanstack/react-query";
+import queryClientOptions from "./queryClientOptions";
+
+const makeQueryClient = () => {
+  return new QueryClient(queryClientOptions);
+};
+
+let browserQueryClient: QueryClient | undefined;
+
+const getQueryClient = () => {
+  if (typeof window === "undefined") {
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+};
+
+export default getQueryClient;

--- a/apps/client/src/shared/apis/query/getQueryClient.ts
+++ b/apps/client/src/shared/apis/query/getQueryClient.ts
@@ -8,12 +8,8 @@ const makeQueryClient = () => {
 let browserQueryClient: QueryClient | undefined;
 
 const getQueryClient = () => {
-  if (typeof window === "undefined") {
-    return makeQueryClient();
-  } else {
-    if (!browserQueryClient) browserQueryClient = makeQueryClient();
-    return browserQueryClient;
-  }
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
 };
 
 export default getQueryClient;

--- a/apps/client/src/shared/apis/query/queryClientOptions.ts
+++ b/apps/client/src/shared/apis/query/queryClientOptions.ts
@@ -1,0 +1,12 @@
+const queryClientOptions = {
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+};
+
+export default queryClientOptions;

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -11,18 +11,19 @@
     "zip": "vite build && node scripts/zip.mjs"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.85.3",
+    "@tanstack/react-query": "^5.85.5",
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
-    "@pivanov/vite-plugin-svg-sprite": "^3.1.3",
     "@crxjs/vite-plugin": "^2.2.0",
     "@eslint/js": "^9.33.0",
     "@pinback/design-system": "workspace:*",
     "@pinback/eslint-config": "workspace:*",
     "@pinback/tailwind-config": "workspace:*",
     "@pinback/typescript-config": "workspace:*",
+    "@pivanov/vite-plugin-svg-sprite": "^3.1.3",
     "@tailwindcss/vite": "^4.1.12",
     "@types/chrome": "^0.0.273",
     "@types/react": "^18.3.5",

--- a/apps/extension/src/apis/axiosInstance.ts
+++ b/apps/extension/src/apis/axiosInstance.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const apiRequest = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiRequest;

--- a/apps/extension/src/apis/query/getQueryClient.ts
+++ b/apps/extension/src/apis/query/getQueryClient.ts
@@ -1,0 +1,19 @@
+import { QueryClient } from "@tanstack/react-query";
+import queryClientOptions from "./queryClientOptions";
+
+const makeQueryClient = () => {
+  return new QueryClient(queryClientOptions);
+};
+
+let browserQueryClient: QueryClient | undefined;
+
+const getQueryClient = () => {
+  if (typeof window === "undefined") {
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+};
+
+export default getQueryClient;

--- a/apps/extension/src/apis/query/getQueryClient.ts
+++ b/apps/extension/src/apis/query/getQueryClient.ts
@@ -8,12 +8,8 @@ const makeQueryClient = () => {
 let browserQueryClient: QueryClient | undefined;
 
 const getQueryClient = () => {
-  if (typeof window === "undefined") {
-    return makeQueryClient();
-  } else {
-    if (!browserQueryClient) browserQueryClient = makeQueryClient();
-    return browserQueryClient;
-  }
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
 };
 
 export default getQueryClient;

--- a/apps/extension/src/apis/query/queryClientOptions.ts
+++ b/apps/extension/src/apis/query/queryClientOptions.ts
@@ -1,0 +1,12 @@
+const queryClientOptions = {
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+};
+
+export default queryClientOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
 
   apps/client:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.85.3
+        version: 5.85.5(react@19.1.1)
+      axios:
+        specifier: ^1.11.0
+        version: 1.11.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -146,8 +152,11 @@ importers:
   apps/extension:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.85.3
+        specifier: ^5.85.5
         version: 5.85.5(react@19.1.1)
+      axios:
+        specifier: ^1.11.0
+        version: 1.11.0
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -2014,6 +2023,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2028,6 +2040,9 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
+
+  axios@1.11.0:
+    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2205,6 +2220,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -2329,6 +2348,10 @@ packages:
   del@5.1.0:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
     engines: {node: '>=8'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2672,6 +2695,15 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2679,6 +2711,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3323,6 +3359,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -6189,6 +6233,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.3
@@ -6204,6 +6250,14 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.3: {}
+
+  axios@1.11.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -6392,6 +6446,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@10.0.1: {}
 
   commander@11.1.0: {}
@@ -6521,6 +6579,8 @@ snapshots:
       p-map: 3.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -7004,6 +7064,8 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -7012,6 +7074,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -7666,6 +7736,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
 


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #10 

## 📄 Tasks
- 의존성 추가
- axios instance 생성
- queryClient 생성

## ⭐ PR Point (To Reviewer)
### 📌 구조
일단 모노레포의 장점을 살린다고 생각하면 packages에 공통 의존성과 설정을 해야한다고 생각했어요.
그래서 처음에는 
```md
/packages/api-client/
├── src/
│   ├── axios/
│   │   └── index.ts  # Axios 관련 로직
│   └── query/
│       ├── getQueryClient.ts
│       ├── queryClientOptions.ts
│       └── index.ts  # Query 관련 로직 export
├── package.json
```

이렇게 api-client라는 패키지를 생성하고, 여기서 두 라이브러리 의존성과 instance, queryClient를 위치시키려고 했어요.
하지만 여기서 드는 생각이 apps안에 있는 client와 extension이 같은 config를 공유할까? 였어요. 환경이 아예 다르고 특히나 extension은 조금 레거시한 설정들이 많아서 이 부분에서 설정이 달라질 수 있겠다고 판단했어요.

물론 최소한의 공통 속성만 packages에 빼두고 각 apps에서 config를 추가로 확장하면 되지 않을까도 생각해봤는데, 애초에 apps에서 useQuery등이나 interceptor와 같이 추가로 설정할 때 필요한 기능들이 각 apps에서도 의존성을 가지고 있어야 한다는 한계가 존재한다는 것을 생각했어요.

그러다보니 어차피 각 apps에서 의존성을 추가해야만 하고, 공통된 속성이 그렇게 많지 않아서 공통의 config를 두는 것이 그렇게 많은 장점을 가지고 있지 않겠다고 판단했어요. 오히려 많은 차이점이 생긴다면 분리하는 것이 좋겠다고 판단하기도 했구요.
그래서 최종적으로는 apps에서 각 의존성을 설치하고, queryClient와 instance를 설정하게 되었어요.

혹시나 좋은 의견이 있다면 공유해주세요!!

### 📌 queryClient에 사용한 싱글톤 패턴
간단하게 queryClient를 생성하는 로직에 싱글톤 패턴을 적용했어요. tanstack query에서 queryClient는 오직 하나만 존재해야 하기 때문에 이 상황이 싱글톤 패턴을 사용하면 좋겠다고 생각이 들었어요.


```ts
const makeQueryClient = () => {
  return new QueryClient(queryClientOptions);
};

let browserQueryClient: QueryClient | undefined;

const getQueryClient = () => {
  if (typeof window === "undefined") {
    return makeQueryClient();
  } else {
    if (!browserQueryClient) browserQueryClient = makeQueryClient();
    return browserQueryClient;
  }
};

export default getQueryClient;
```

이렇게 구현해서 사용하는 곳에서 아래와 같이 get 함수로 받아서 사용하면 돼요!
```ts
const queryClient = getQueryClient();
```

그리고.... 스웨거 OAS로 type generate해주는 라이브러리 도입을 해야하는데.. 모노레포에서의 러닝 커브가 있어서(제가..조금 부족한 지식이 있어서 그런거 같아요) 일단 이대로 작업하고 이후에 추가로 넣어볼게요...!!

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 앱과 확장 프로그램에 공통 API 클라이언트와 데이터 캐싱 레이어를 도입해 네트워크 요청을 일관되게 처리하고 초기 로딩을 단축했습니다.
  - 기본 캐싱 정책(5분)과 재시도 제한으로 불필요한 재요청을 줄여 화면 전환 시 더 매끄러운 데이터 표시가 가능합니다.
  - 클라이언트 재사용으로 메모리 사용과 중복 작업을 감소시켰습니다.
- Chores
  - 네트워크 통신 및 데이터 상태 관리 의존성(@tanstack/react-query 추가/업데이트, axios 추가)을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->