### PR TITLE
Feat(onboarding): 온보딩 회원가입 api 연결

### DIFF
--- a/apps/client/src/pages/onBoarding/components/funnel/AlarmBox.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/AlarmBox.tsx
@@ -2,6 +2,7 @@ import { cva } from 'class-variance-authority';
 import TimePicker from '../timePicker/TimePicker';
 import { AlarmsType } from '@constants/alarms';
 import { useState } from 'react';
+import { normalizeTime } from '@pages/onBoarding/utils/formatRemindTime';
 interface AlarmBoxProps {
   select: 1 | 2 | 3;
   isDisabled: boolean;
@@ -57,7 +58,7 @@ const AlarmBox = ({ select, isDisabled, onClick }: AlarmBoxProps) => {
       {select === 3 && isDisabled && (
         <>
           {AlarmsType[2].time && (
-            <p className="caption2-m text-font-gray-3">{AlarmsType[2].time}</p>
+            <p className="caption2-m text-font-gray-3">{normalizeTime(AlarmsType[2].time)}</p>
           )}
 
           {showPicker && (

--- a/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
@@ -8,7 +8,8 @@ import FinalStep from './step/FinalStep';
 import { cva } from 'class-variance-authority';
 import { usePostSignUp } from '@shared/apis/queries';
 const stepProgress = [{ progress: 30 }, { progress: 60 }, { progress: 100 }];
-
+import { AlarmsType } from '@constants/alarms';
+import { normalizeTime } from '@pages/onBoarding/utils/formatRemindTime';
 const variants = {
   slideIn: (direction: number) => ({
     x: direction > 0 ? 200 : -200,
@@ -65,17 +66,22 @@ const MainCard = () => {
     }
   };
 
+const [remindTime, setRemindTime] = useState('09:00');
   const nextStep = () => {
+    console.log(step)
     if (step === 3) {
-      // 이거 이후에 api 붙일 자리 표시임! console.log('선택된 알람:', AlarmsType[alarmSelected - 1].time);
+      // 이거 이후에 api 붙일 자리 표시임! 
+      const raw = AlarmsType[alarmSelected - 1].time;
+      setRemindTime(normalizeTime(raw))
     }
     if (step < 5) {
+
       setDirection(1);
       setStep((prev) => prev + 1);
     } else if (step === 5) {
       postSignData({
             "email": "tesdfdfsst@gmail.com", 
-            "remindDefault": "08:00", 
+            "remindDefault": remindTime, 
             "fcmToken": "adlfdjlajlkadfsjlkfdsdfsdfsdfsdfsa"
         },
         {

--- a/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
@@ -71,14 +71,15 @@ const [remindTime, setRemindTime] = useState('09:00');
     console.log(step)
     if (step === 3) {
       // 이거 이후에 api 붙일 자리 표시임! 
-      const raw = AlarmsType[alarmSelected - 1].time;
-      setRemindTime(normalizeTime(raw))
+      
     }
     if (step < 5) {
-
       setDirection(1);
       setStep((prev) => prev + 1);
     } else if (step === 5) {
+      const raw = AlarmsType[alarmSelected - 1].time;
+      setRemindTime(normalizeTime(raw));
+
       postSignData({
             "email": "tesdfdfsst@gmail.com", 
             "remindDefault": remindTime, 

--- a/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
@@ -6,6 +6,7 @@ import AlarmStep from './step/AlarmStep';
 import MacStep from './step/MacStep';
 import FinalStep from './step/FinalStep';
 import { cva } from 'class-variance-authority';
+import { usePostSignUp } from '@shared/apis/queries';
 const stepProgress = [{ progress: 30 }, { progress: 60 }, { progress: 100 }];
 
 const variants = {
@@ -36,6 +37,8 @@ const MainCard = () => {
   const [direction, setDirection] = useState(0);
   const [alarmSelected, setAlarmSelected] = useState<1 | 2 | 3>(1);
   const [isMac, setIsMac] = useState(false);
+  // api 구간
+  const {mutate:postSignData} = usePostSignUp();
 
   useEffect(() => {
     const ua = navigator.userAgent.toLowerCase();
@@ -70,7 +73,19 @@ const MainCard = () => {
       setDirection(1);
       setStep((prev) => prev + 1);
     } else if (step === 5) {
-      window.location.href = '/';
+      postSignData({
+            "email": "tesdfdfsst@gmail.com", 
+            "remindDefault": "08:00", 
+            "fcmToken": "adlfdjlajlkadfsjlkfdsdfsdfsdfsdfsa"
+        },
+        {
+          onSuccess:()=>{
+            window.location.href = '/';
+           }
+        }
+      )
+      
+      
     }
   };
 

--- a/apps/client/src/pages/onBoarding/utils/formatRemindTime.ts
+++ b/apps/client/src/pages/onBoarding/utils/formatRemindTime.ts
@@ -1,0 +1,26 @@
+export function normalizeTime(input: string): string {
+  let hours = 0;
+  let minutes = 0;
+
+  const ampmMatch = input.match(/(AM|PM)\s?(\d{1,2}):(\d{1,2})/i);
+  if (ampmMatch) {
+    const [, ampm, h, m] = ampmMatch;
+    hours = parseInt(h, 10);
+    minutes = parseInt(m, 10);
+
+    if (ampm.toUpperCase() === "PM" && hours < 12) {
+      hours += 12;
+    }
+    if (ampm.toUpperCase() === "AM" && hours === 12) {
+      hours = 0; // 12 AM → 00시
+    }
+  } else {
+    const [h, m] = input.split(":");
+    hours = parseInt(h, 10);
+    minutes = parseInt(m, 10);
+  }
+
+  const hh = String(hours).padStart(2, "0");
+  const mm = String(minutes).padStart(2, "0");
+  return `${hh}:${mm}`;
+}

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -28,6 +28,6 @@ export interface postSignUpRequest {
 }
 
 export const postSignUp = async (data: postSignUpRequest) => {
-  const response = await apiRequest.post('/api/v1/auth/signup', {data});
+  const response = await apiRequest.post('/api/v1/auth/signup', data);
   return response.data;
 };

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -27,7 +27,7 @@ export interface postSignUpRequest {
   fcmToken: string
 }
 
-export const postSignUp = async (data: postSignUpRequest) => {
-  const response = await apiRequest.post('/api/v1/auth/signup', data);
-  return response.data;
+export const postSignUp = async (responsedata: postSignUpRequest) => {
+  const {data} = await apiRequest.post('/api/v1/auth/signup', responsedata);
+  return data;
 };

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -20,3 +20,14 @@ export const getAcorns = async () => {
   });
   return data.data;
 };
+
+export interface postSignUpRequest {
+  email: string,
+  remindDefault: string,
+  fcmToken: string
+}
+
+export const postSignUp = async (data: postSignUpRequest) => {
+  const response = await apiRequest.post('/api/v1/auth/signup', {data});
+  return response.data;
+};

--- a/apps/client/src/shared/apis/queries.ts
+++ b/apps/client/src/shared/apis/queries.ts
@@ -31,7 +31,6 @@ export const usePostSignUp = () => {
   return useMutation({
     mutationFn: (data: postSignUpRequest) => postSignUp(data),
     onSuccess: (data) => {
-      // postSignUp에서 axios 같은 걸 리턴한다고 가정
       const newToken = data?.data?.token || data?.token;
 
       if (newToken) {

--- a/apps/client/src/shared/apis/queries.ts
+++ b/apps/client/src/shared/apis/queries.ts
@@ -27,15 +27,21 @@ export const useGetArcons = (): UseQueryResult<AcornsResponse, AxiosError> => {
   });
 };
 
-export const usePostSignUp = () =>{
+export const usePostSignUp = () => {
   return useMutation({
     mutationFn: (data: postSignUpRequest) => postSignUp(data),
     onSuccess: (data) => {
+      // postSignUp에서 axios 같은 걸 리턴한다고 가정
+      const newToken = data?.data?.token || data?.token;
+
+      if (newToken) {
+        localStorage.setItem("token", newToken);
+      }
+
       console.log("회원가입 성공:", data);
     },
     onError: (error) => {
       console.error("회원가입 실패:", error);
-
     },
   });
-}
+};

--- a/apps/client/src/shared/apis/queries.ts
+++ b/apps/client/src/shared/apis/queries.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, UseQueryResult } from '@tanstack/react-query';
-import { getDashboardCategories, postCategory } from '@shared/apis/axios';
+import { getDashboardCategories, postCategory, postSignUp, postSignUpRequest } from '@shared/apis/axios';
 import { AxiosError } from 'axios';
 import { DashboardCategoriesResponse, AcornsResponse } from '@shared/types/api';
 import { getAcorns } from './axios';
@@ -26,3 +26,16 @@ export const useGetArcons = (): UseQueryResult<AcornsResponse, AxiosError> => {
     queryFn: () => getAcorns(),
   });
 };
+
+export const usePostSignUp = () =>{
+  return useMutation({
+    mutationFn: (data: postSignUpRequest) => postSignUp(data),
+    onSuccess: (data) => {
+      console.log("회원가입 성공:", data);
+    },
+    onError: (error) => {
+      console.error("회원가입 실패:", error);
+
+    },
+  });
+}


### PR DESCRIPTION
## 📌 Related Issues

- close #84 

## 📄 Tasks
1. 온보딩 signIn api 연결 & 로컬스토리지 저장
2. 성공 후 대시보드로 연결
3. 타임 피커 시간 포맷팅

## ⭐ PR Point (To Reviewer)
현재는 임의 로우데이터로 api 연결했습니당
1. 이후 FCM 연결 예정
2. 익스텐션에서 메일 정보를 줘야해서! 추후에 메일도 연결하겠습니다
3. 회원가입 완료 후 토큰도 익스텐션에 전달 로직 추가 예정

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 온보딩 마지막 단계에서 가입 정보를 서버로 제출하고, 성공 시 자동으로 홈으로 이동합니다.
  * 이메일, 알림 기본값(remindDefault) 및 푸시 토큰을 함께 전송해 초기 계정 설정이 반영됩니다.

* 개선
  * 알림 시간이 일관된 24시간 형식(HH:MM)으로 표시되어 더 명확합니다.
  * 온보딩 흐름이 서버 연동으로 정비되어 가입 처리 반영이 즉시 이루어집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->