### PR TITLE
Api(client): 아티클 읽음 상태 변경 API 연결

### DIFF
--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -13,13 +13,26 @@ import { useAnchoredMenu } from '@shared/hooks/useAnchoredMenu';
 import { belowOf } from '@shared/utils/anchorPosition';
 import NoArticles from '@pages/myBookmark/components/NoArticles/NoArticles';
 import { Icon } from '@pinback/design-system/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePutArticleReadStatus } from '@shared/apis/queries';
 
 const MyBookmark = () => {
   const [activeBadge, setActiveBadge] = useState<'all' | 'notRead'>('all');
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
   const [searchParams] = useSearchParams();
   const category = searchParams.get('category');
   const categoryId = searchParams.get('id');
-  const [isEditOpen, setIsEditOpen] = useState(false);
+
+  const queryClient = useQueryClient();
+  const { data: articles } = useGetBookmarkArticles(0, 20);
+  const { data: unreadArticles } = useGetBookmarkUnreadArticles(0, 20);
+  const { data: categoryArticles } = useGetCategoryBookmarkArticles(
+    categoryId,
+    1,
+    10
+  );
+  const { mutate: updateToReadStatus } = usePutArticleReadStatus();
 
   const {
     state: menu,
@@ -31,14 +44,6 @@ const MyBookmark = () => {
 
   const getBookmarkTitle = (id: number | null) =>
     id == null ? '' : (REMIND_MOCK_DATA.find((d) => d.id === id)?.title ?? '');
-
-  const { data: articles } = useGetBookmarkArticles(0, 20);
-  const { data: unreadArticles } = useGetBookmarkUnreadArticles(0, 20);
-  const { data: categoryArticles } = useGetCategoryBookmarkArticles(
-    categoryId,
-    1,
-    10
-  );
 
   const articlesToDisplay =
     activeBadge === 'all' ? articles?.articles : unreadArticles?.articles;
@@ -93,7 +98,27 @@ const MyBookmark = () => {
               content={article.memo}
               category={article.category.categoryName}
               date={new Date(article.createdAt).toLocaleDateString('ko-KR')}
-              onClick={() => {}}
+              onClick={() => {
+                window.open(article.url, '_blank');
+
+                updateToReadStatus(article.articleId, {
+                  onSuccess: () => {
+                    // TODO: 쿼리키 팩토리 패턴 적용
+                    queryClient.invalidateQueries({
+                      queryKey: ['bookmarkReadArticles'],
+                    });
+                    queryClient.invalidateQueries({
+                      queryKey: ['bookmarkUnreadArticles'],
+                    });
+                    queryClient.invalidateQueries({
+                      queryKey: ['categoryBookmarkArticles'],
+                    });
+                  },
+                  onError: (error) => {
+                    console.error(error);
+                  },
+                });
+              }}
               onOptionsClick={(e) =>
                 openMenu(article.articleId, e.currentTarget)
               }

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -9,9 +9,23 @@ import { useGetRemindArticles } from '@pages/remind/apis/queries';
 import { formatLocalDateTime } from '@shared/utils/formatDateTime';
 import NoReadArticles from '@pages/remind/components/noReadArticles/NoReadArticles';
 import NoUnreadArticles from '@pages/remind/components/noUnreadArticles/NoUnreadArticles';
+import { usePutArticleReadStatus } from '@shared/apis/queries';
+import { useQueryClient } from '@tanstack/react-query';
 
 const Remind = () => {
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [activeBadge, setActiveBadge] = useState<'read' | 'notRead'>('notRead');
+  const formattedDate = formatLocalDateTime();
+
+  const queryClient = useQueryClient();
+
+  const { mutate: updateToReadStatus } = usePutArticleReadStatus();
+  const { data } = useGetRemindArticles(
+    formattedDate,
+    activeBadge === 'read',
+    1,
+    10
+  );
 
   const {
     state: menu,
@@ -23,15 +37,6 @@ const Remind = () => {
 
   const getItemTitle = (id: number | null) =>
     id == null ? '' : (REMIND_MOCK_DATA.find((d) => d.id === id)?.title ?? '');
-  const [activeBadge, setActiveBadge] = useState<'read' | 'notRead'>('notRead');
-  const formattedDate = formatLocalDateTime();
-
-  const { data } = useGetRemindArticles(
-    formattedDate,
-    activeBadge === 'read',
-    1,
-    10
-  );
 
   const handleBadgeClick = (badgeType: 'read' | 'notRead') => {
     setActiveBadge(badgeType);
@@ -72,6 +77,20 @@ const Remind = () => {
                 onOptionsClick: (e) =>
                   openMenu(article.category.categoryId, e.currentTarget),
               })}
+              onClick={() => {
+                window.open(article.url, '_blank');
+
+                updateToReadStatus(article.articleId, {
+                  onSuccess: () => {
+                    queryClient.invalidateQueries({
+                      queryKey: ['remindArticles'],
+                    });
+                  },
+                  onError: (error) => {
+                    console.error(error);
+                  },
+                });
+              }}
             />
           ))}
         </div>

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -39,6 +39,13 @@ export const postSignUp = async (responsedata: postSignUpRequest) => {
   return data;
 };
 
+export const putArticleReadStatus = async (articleId: number) => {
+  const { data } = await apiRequest.put(
+    `/api/v1/articles/${articleId}/readStatus`
+  );
+  return data;
+};
+
 export const deleteCategory = async (id: number) => {
   const response = await apiRequest.delete(`/api/v1/categories/${id}`);
   return response;

--- a/apps/client/src/shared/apis/queries.ts
+++ b/apps/client/src/shared/apis/queries.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, UseQueryResult } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
 import {
   deleteCategory,
   getDashboardCategories,
@@ -6,10 +11,15 @@ import {
   postSignUp,
   postSignUpRequest,
   putCategory,
+  getAcorns,
+  putArticleReadStatus,
 } from '@shared/apis/axios';
 import { AxiosError } from 'axios';
-import { DashboardCategoriesResponse, AcornsResponse } from '@shared/types/api';
-import { getAcorns } from './axios';
+import {
+  DashboardCategoriesResponse,
+  AcornsResponse,
+  ArticleReadStatusResponse,
+} from '@shared/types/api';
 
 export const useGetDashboardCategories = (): UseQueryResult<
   DashboardCategoriesResponse,
@@ -61,5 +71,15 @@ export const usePostSignUp = () => {
     onError: (error) => {
       console.error('회원가입 실패:', error);
     },
+  });
+};
+
+export const usePutArticleReadStatus = (): UseMutationResult<
+  ArticleReadStatusResponse,
+  AxiosError,
+  number
+> => {
+  return useMutation({
+    mutationFn: (articleId: number) => putArticleReadStatus(articleId),
   });
 };

--- a/apps/client/src/shared/types/api.ts
+++ b/apps/client/src/shared/types/api.ts
@@ -12,3 +12,8 @@ export type AcornsResponse = {
   acornCount: number;
   remindDateTime: string;
 };
+
+export interface ArticleReadStatusResponse {
+  acornCount: number;
+  acornCollected: boolean;
+}

--- a/packages/design-system/src/components/card/BaseCard.tsx
+++ b/packages/design-system/src/components/card/BaseCard.tsx
@@ -1,10 +1,14 @@
 interface BaseCardProps {
+  onClick?: () => void;
   children: React.ReactNode;
 }
 
-const BaseCard = ({ children }: BaseCardProps) => {
+const BaseCard = ({ children, onClick }: BaseCardProps) => {
   return (
-    <div className="border-gray200 w-[24.8rem] overflow-hidden rounded-[1.2rem] border bg-white">
+    <div
+      onClick={onClick}
+      className="border-gray200 w-[24.8rem] overflow-hidden rounded-[1.2rem] border bg-white"
+    >
       {children}
     </div>
   );

--- a/packages/design-system/src/components/card/MyBookmarkCard.tsx
+++ b/packages/design-system/src/components/card/MyBookmarkCard.tsx
@@ -18,10 +18,11 @@ const MyBookmarkCard = ({
   category,
   imageUrl,
   date,
+  onClick,
   onOptionsClick,
 }: MyBookmarkCardProps) => {
   return (
-    <BaseCard>
+    <BaseCard onClick={onClick}>
       <div className="flex h-[12rem] w-full items-center justify-center overflow-hidden bg-[#F8F8FA]">
         {imageUrl ? (
           <img src={imageUrl} className="h-full w-full object-cover" />

--- a/packages/design-system/src/components/card/RemindCard.tsx
+++ b/packages/design-system/src/components/card/RemindCard.tsx
@@ -18,10 +18,11 @@ const RemindCard = ({
   category,
   imageUrl,
   timeRemaining,
+  onClick,
   onOptionsClick,
 }: RemindCardProps) => {
   return (
-    <BaseCard>
+    <BaseCard onClick={onClick}>
       <div className="bg-gray900 flex items-center gap-[0.4rem] py-[1.2rem] pl-[1.6rem] text-sm text-white">
         <Icon name="ic_clock_active" />
         <span className="body2-m text-main400 mr-[0.2rem]">


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #94 

## 📄 Tasks
- 아티클 읽음 상태 변경 API 연결

## ⭐ PR Point (To Reviewer)
크게 이슈되는 것은 없는데, query invalidate 하는 로직이 너무 지저분해지고 쿼리키 관리가 너무 어렵네요.
그래서 이번 스프린트 마무리하고 
1. 쿼리키 자체 상수화
2. 쿼리키 팩토리 패턴 or 팩토리 패턴 적용
3. queryOptions등 관련 쿼리 옵션들 중앙화

관련 리팩토링 진행하겠습니다!

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

https://github.com/user-attachments/assets/875ab3b8-12c6-4716-9707-00eb88747dc3




<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 북마크/리마인드 카드 클릭 시 새 탭으로 기사 열기 및 즉시 읽음 처리.
  - 읽음 처리 후 목록이 자동 새로고침되어 읽음/미읽음 상태와 배지 카운트가 즉시 반영.
  - 북마크 편집을 위한 모달 편집 워크플로우 추가.

- 리팩터링
  - 데이터 요청 로직을 공용 훅으로 통합하여 중복 제거 및 일관성 향상.

- 디자인 시스템
  - 카드 컴포넌트에 onClick 지원 추가로 카드 전체 영역 클릭 인터랙션 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->