### PR TITLE
Fix(client): category edit query string sync

### DIFF
--- a/apps/client/src/shared/components/sidebar/Sidebar.tsx
+++ b/apps/client/src/shared/components/sidebar/Sidebar.tsx
@@ -19,12 +19,14 @@ import {
 } from '@shared/apis/queries';
 import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 export function Sidebar() {
   const [newCategoryName, setNewCategoryName] = useState('');
   const [toastIsOpen, setToastIsOpen] = useState(false);
 
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { data: categories } = useGetDashboardCategories();
   const { mutate: patchCategory } = usePutCategory();
@@ -40,6 +42,7 @@ export function Sidebar() {
     selectCategory,
     goLevel,
     setSelectedCategoryId,
+    setActiveTab,
   } = useSidebarNav();
 
   const { popup, openCreate, openEdit, openDelete, close } =
@@ -60,9 +63,11 @@ export function Sidebar() {
     setNewCategoryName(name);
   };
 
-  useEffect(() => {
-    setToastIsOpen(false);
-  }, [popup]);
+  const moveNewCategory = (id: number) => {
+    navigate(`/my-bookmarks?id=${id}&category=${newCategoryName}`);
+    setActiveTab('mybookmark');
+    setSelectedCategoryId(id);
+  };
 
   const handleCreateCategory = () => {
     createCategory(newCategoryName, {
@@ -82,9 +87,10 @@ export function Sidebar() {
       { id, categoryName: newCategoryName },
       {
         onSuccess: () => {
-          setNewCategoryName('');
           queryClient.invalidateQueries({ queryKey: ['dashboardCategories'] });
+          setNewCategoryName('');
           close();
+          moveNewCategory(id);
         },
         onError: () => {
           setToastIsOpen(true);
@@ -109,6 +115,10 @@ export function Sidebar() {
     setToastIsOpen(false);
     close();
   };
+
+  useEffect(() => {
+    setToastIsOpen(false);
+  }, [popup]);
 
   if (isPending) return <div></div>;
   if (isError) return <div></div>;


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #140 

## 📄 Tasks
- category params sync

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->

## ⭐ PR Point (To Reviewer)
이전에 사이드바에서 카테고리를 수정하면 대시보드와 쿼리 스트링에 해당 수정된 카테고리가 바로 반영이 안된다는 문제가 있었어요.
사이드바에 있는 카테고리는 invalidate 처리가 되어 있어서 바로 반영이 되지만, 이외 UI나 쿼리 스트링에는 따로 해당 처리가 안되어 있었기 때문에 로직을 추가했어요.

```ts
 const moveNewCategory = (id: number) => {
    navigate(`/my-bookmarks?id=${id}&category=${newCategoryName}`);
    setActiveTab('mybookmark');
    setSelectedCategoryId(id);
  };
```

이와 같이 새로운 카테고리를 담은 쿼리 스트링을 포함한 주소로 라우팅을 해주고, tab과 카테고리 설정도 해주었어요.
사실 위 문제에 대한 직접적인 해결은 navigate만 해주면 되지만, 카테고리를 수정하면 그 카테고리로 이동되는게 UX적으로 자연스럽다고 생각해서 아래 2줄을 추가해줬어요.

이를 수정하는 `mutate` 함수의 `onSuccess`에 아래와 같이 추가해서 문제를 해결했어요.

```ts
 onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ['dashboardCategories'] });
      setNewCategoryName('');
      close();
      moveNewCategory(id);
    },
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 새 카테고리 생성·수정 후 자동으로 해당 카테고리로 이동하고 ‘내 북마크’ 탭을 활성화합니다.
  - 사이드바에서 새로 이동한 카테고리를 즉시 선택하여 상태를 동기화합니다.
  - 대시보드 카테고리 목록이 자동으로 갱신됩니다.

- **Bug Fixes**
  - 팝업 전환 시 토스트 메시지가 올바르게 초기화되도록 타이밍을 조정해 중복/잔류 표시를 방지했습니다.

- **Refactor**
  - 사이드바 내 내비게이션 상태 연동을 정리해 전환 흐름을 일관되게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->