### PR TITLE
Fix/#155/remind edit time

### DIFF
--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -241,6 +241,7 @@ const MyBookmark = () => {
           />
           <div className="absolute inset-0 flex items-center justify-center p-4">
             <CardEditModal
+              key={articleDetail.id}
               onClose={() => setIsEditOpen(false)}
               prevData={articleDetail}
             />

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -192,6 +192,7 @@ const Remind = () => {
           />
           <div className="absolute inset-0 flex items-center justify-center p-4">
             <CardEditModal
+              key={articleDetail.id}
               onClose={() => setIsEditOpen(false)}
               prevData={articleDetail}
             />

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -23,7 +23,7 @@ export const putCategory = async (id: number, categoryName: string) => {
 
 export const getAcorns = async () => {
   const now = formatLocalDateTime(new Date());
-  const { data } = await apiRequest.get('/api/v1/users/acorns?now=', {
+  const { data } = await apiRequest.get('/api/v1/users/acorns?', {
     params: { now },
   });
   return data.data;


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #155

## 📄 Tasks

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->
리마인드 edit 창을 키고 닫을 때마다 시간이 제멋대로 지정되는 오류 발생
* 리마인드 수정시 오류 1
* 리마인드 수정시 오류 2
* (노션 qa 보드 참고)

## ⭐ PR Point (To Reviewer)

### 원인
React는 컴포넌트의 state를 트리에서의 위치에 묶어서 보존하는데 같은 컴포넌트를 같은 위치에 계속 렌더링하면 이전 state를 그대로 유지해버려요. 그래서 북마크에서 모달을 열 때마다 이전 아티클에서 쓰던 내부 state(날짜/시간)가 carry-over”되는 현상이 발생했습니다.

“같은 위치에 렌더된 동일 컴포넌트는 상태가 보존된다.” 즉, 부모가 모달을 조건부로 토글만 하고, 모달의 위치/타입이 같다면 상태가 초기화되지 않게됩니다.

### 해결 방법
React는 같은 위치에 같은 타입의 컴포넌트가 렌더되면 기존 인스턴스를 재사용합니다. 그래서 prevData가 바뀌어도, 모달은 그대로고 내부 useState 값들이 유지되는 state carry-over현상이 발생합니다 [그래서 리액트에서는 다른 대상을 보여줄 때처럼  컴포넌트 트리의 정체성이 바뀌어야 하는 경우 key를 달아 새 인스턴스로 간주시키라고 말하고있어요.](https://react.dev/learn/preserving-and-resetting-state)` key={articleDetail.id}` 를 주면, id가 달라질 때마다 다른 컴포넌트로 간주되어 기존 것을 언마운트하며 새로 마운트합니다. 



모든 useState가 초기화되고,

useEffect도 새로 실행되고,
[React](https://react.dev/learn/preserving-and-resetting-state)
<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->
