### PR TITLE
Feat(client): article intersection observer로 infinite scroll 구현

### DIFF
--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -133,10 +133,6 @@ const MyBookmark = () => {
     return null;
   };
 
-  if (articlesToDisplay.length === 0) {
-    return <div>Loading...</div>;
-  }
-
   const totalArticleCount =
     (category
       ? categoryArticlesData?.pages[0]?.totalArticle

--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -1,5 +1,5 @@
 import { Badge, PopupContainer } from '@pinback/design-system/ui';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   useGetBookmarkArticles,
   useGetBookmarkUnreadArticles,
@@ -21,11 +21,11 @@ import {
 } from '@shared/apis/queries';
 import NoUnreadArticles from '@pages/myBookmark/components/noUnreadArticles/NoUnreadArticles';
 import FetchCard from './components/fetchCard/FetchCard';
+import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
 const MyBookmark = () => {
   const [activeBadge, setActiveBadge] = useState<'all' | 'notRead'>('all');
   const [isEditOpen, setIsEditOpen] = useState(false);
-
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
 
@@ -34,15 +34,30 @@ const MyBookmark = () => {
   const category = searchParams.get('category');
   const categoryId = searchParams.get('id');
 
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   const { mutate: updateToReadStatus } = usePutArticleReadStatus();
   const { mutate: deleteArticle } = useDeleteRemindArticle();
-  const { data: articles, isPending } = useGetBookmarkArticles(0, 20);
-  const { data: unreadArticles } = useGetBookmarkUnreadArticles(0, 20);
-  const { data: categoryArticles } = useGetCategoryBookmarkArticles(
+
+  const {
+    data: articlesData,
+    fetchNextPage: fetchNextArticles,
+    hasNextPage: hasNextArticles,
+  } = useGetBookmarkArticles();
+
+  const {
+    data: unreadArticlesData,
+    fetchNextPage: fetchNextUnreadArticles,
+    hasNextPage: hasNextUnreadArticles,
+  } = useGetBookmarkUnreadArticles();
+
+  const {
+    data: categoryArticlesData,
+    fetchNextPage: fetchNextCategoryArticles,
+    hasNextPage: hasNextCategoryArticles,
+  } = useGetCategoryBookmarkArticles(
     categoryId,
-    activeBadge === 'notRead' ? false : null,
-    0,
-    10
+    activeBadge === 'notRead' ? false : null
   );
 
   const { mutate: getArticleDetail, data: articleDetail } =
@@ -57,10 +72,28 @@ const MyBookmark = () => {
   } = useAnchoredMenu((anchor) => belowOf(anchor, 8));
 
   const articlesToDisplay = category
-    ? categoryArticles?.articles
+    ? (categoryArticlesData?.pages.flatMap((page) => page.articles) ?? [])
     : activeBadge === 'all'
-      ? articles?.articles
-      : unreadArticles?.articles;
+      ? (articlesData?.pages.flatMap((page) => page.articles) ?? [])
+      : (unreadArticlesData?.pages.flatMap((page) => page.articles) ?? []);
+
+  const hasNextPage = category
+    ? hasNextCategoryArticles
+    : activeBadge === 'all'
+      ? hasNextArticles
+      : hasNextUnreadArticles;
+
+  const fetchNextPage = category
+    ? fetchNextCategoryArticles
+    : activeBadge === 'all'
+      ? fetchNextArticles
+      : fetchNextUnreadArticles;
+
+  const observerRef = useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    root: scrollContainerRef,
+  });
 
   const handleDeleteArticle = (id: number) => {
     deleteArticle(id, {
@@ -90,18 +123,29 @@ const MyBookmark = () => {
   };
 
   const EmptyStateComponent = () => {
-    if (articles?.totalArticle === 0) {
-      return <NoArticles />;
+    if (articlesToDisplay.length === 0) {
+      const totalArticlesInAllView = articlesData?.pages[0]?.totalArticle;
+      if (totalArticlesInAllView === 0) {
+        return <NoArticles />;
+      }
+      return <NoUnreadArticles />;
     }
-    return <NoUnreadArticles />;
+    return null;
   };
 
-  // TODO: 로딩 상태 디자인 필요
-  if (isPending) {
+  if (articlesToDisplay.length === 0) {
     return <div>Loading...</div>;
   }
 
-  console.log(category);
+  const totalArticleCount =
+    (category
+      ? categoryArticlesData?.pages[0]?.totalArticle
+      : articlesData?.pages[0]?.totalArticle) ?? 0;
+
+  const totalUnreadArticleCount =
+    (category
+      ? categoryArticlesData?.pages[0]?.totalUnreadArticle
+      : articlesData?.pages[0]?.totalUnreadArticle) ?? 0;
 
   return (
     <div className="flex h-screen flex-col py-[5.2rem] pl-[8rem] pr-[5rem]">
@@ -124,32 +168,27 @@ const MyBookmark = () => {
       <div className="mt-[3rem] flex gap-[2.4rem]">
         <Badge
           text="전체보기"
-          countNum={
-            category
-              ? categoryArticles?.totalArticle || 0
-              : articles?.totalArticle || 0
-          }
+          countNum={totalArticleCount}
           onClick={() => handleBadgeClick('all')}
           isActive={activeBadge === 'all'}
         />
         <Badge
           text="안 읽음"
-          countNum={
-            category
-              ? categoryArticles?.totalUnreadArticle || 0
-              : articles?.totalUnreadArticle || 0
-          }
+          countNum={totalUnreadArticleCount}
           onClick={() => handleBadgeClick('notRead')}
           isActive={activeBadge === 'notRead'}
         />
       </div>
 
-      {articlesToDisplay && articlesToDisplay.length > 0 ? (
-        <div className="scrollbar-hide mt-[2.6rem] flex h-screen flex-wrap gap-[1.6rem] overflow-y-auto scroll-smooth">
+      {articlesToDisplay.length > 0 ? (
+        <div
+          ref={scrollContainerRef}
+          className="scrollbar-hide mt-[2.6rem] flex h-screen flex-wrap content-start gap-[1.6rem] overflow-y-auto scroll-smooth"
+        >
           {articlesToDisplay.map((article) => (
             <FetchCard
               key={article.articleId}
-              article={article} // article 객체를 통째로 넘겨줍니다.
+              article={article}
               onClick={() => {
                 window.open(article.url, '_blank');
                 updateToReadStatus(article.articleId, {
@@ -164,9 +203,7 @@ const MyBookmark = () => {
                     queryClient.invalidateQueries({
                       queryKey: ['categoryBookmarkArticles'],
                     });
-                    queryClient.invalidateQueries({
-                      queryKey: ['arcons'],
-                    });
+                    queryClient.invalidateQueries({ queryKey: ['arcons'] });
                   },
                   onError: (error) => {
                     console.error(error);
@@ -179,6 +216,7 @@ const MyBookmark = () => {
               }}
             />
           ))}
+          <div ref={observerRef} style={{ height: '1px', width: '100%' }} />
         </div>
       ) : (
         <EmptyStateComponent />
@@ -203,7 +241,6 @@ const MyBookmark = () => {
         onClose={closeMenu}
       />
 
-      {/* 삭제 확인 모달 */}
       {isDeleteOpen && (
         <div className="fixed inset-0" aria-modal="true" role="dialog">
           <div
@@ -232,7 +269,6 @@ const MyBookmark = () => {
         </div>
       )}
 
-      {/* 편집 모달 */}
       {isEditOpen && articleDetail && (
         <div className="fixed inset-0 z-[1000]" aria-modal="true" role="dialog">
           <div

--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -1,5 +1,5 @@
 import { Badge, PopupContainer } from '@pinback/design-system/ui';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import {
   useGetBookmarkArticles,
   useGetBookmarkUnreadArticles,
@@ -20,7 +20,7 @@ import {
   usePutArticleReadStatus,
 } from '@shared/apis/queries';
 import NoUnreadArticles from '@pages/myBookmark/components/noUnreadArticles/NoUnreadArticles';
-import FetchCard from './components/fetchCard/FetchCard';
+import FetchCard from '@pages/myBookmark/components/fetchCard/FetchCard';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
 const MyBookmark = () => {

--- a/apps/client/src/pages/myBookmark/apis/queries.ts
+++ b/apps/client/src/pages/myBookmark/apis/queries.ts
@@ -1,46 +1,53 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import {
   getBookmarkArticles,
   getBookmarkUnreadArticles,
   getCategoryBookmarkArticles,
 } from './axios';
-import {
-  BookmarkArticleResponse,
-  CategoryBookmarkArticleResponse,
-  UnreadBookmarkArticleResponse,
-} from '@pages/myBookmark/types/api';
 
-export const useGetBookmarkArticles = (
-  page: number,
-  size: number
-): UseQueryResult<BookmarkArticleResponse, AxiosError> => {
-  return useQuery({
-    queryKey: ['bookmarkReadArticles', page, size],
-    queryFn: () => getBookmarkArticles(page, size),
+export const useGetBookmarkArticles = () => {
+  return useInfiniteQuery({
+    queryKey: ['bookmarkReadArticles'],
+    queryFn: ({ pageParam = 0 }) => getBookmarkArticles(pageParam, 20),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.articles.length === 0) {
+        return undefined;
+      }
+      return allPages.length;
+    },
   });
 };
 
-export const useGetBookmarkUnreadArticles = (
-  page: number,
-  size: number
-): UseQueryResult<UnreadBookmarkArticleResponse, AxiosError> => {
-  return useQuery({
-    queryKey: ['bookmarkUnreadArticles', page, size],
-    queryFn: () => getBookmarkUnreadArticles(page, size),
+export const useGetBookmarkUnreadArticles = () => {
+  return useInfiniteQuery({
+    queryKey: ['bookmarkUnreadArticles'],
+    queryFn: ({ pageParam = 0 }) => getBookmarkUnreadArticles(pageParam, 20),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.articles.length === 0) {
+        return undefined;
+      }
+      return allPages.length;
+    },
   });
 };
 
 export const useGetCategoryBookmarkArticles = (
   categoryId: string | null,
-  readStatus: boolean | null,
-  page: number,
-  size: number
-): UseQueryResult<CategoryBookmarkArticleResponse, AxiosError> => {
-  return useQuery({
-    queryKey: ['categoryBookmarkArticles', readStatus, categoryId, page, size],
-    queryFn: () =>
-      getCategoryBookmarkArticles(categoryId, readStatus, page, size),
+  readStatus: boolean | null
+) => {
+  return useInfiniteQuery({
+    queryKey: ['categoryBookmarkArticles', readStatus, categoryId],
+    queryFn: ({ pageParam = 0 }) =>
+      getCategoryBookmarkArticles(categoryId, readStatus, pageParam, 20),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.articles.length === 0) {
+        return undefined;
+      }
+      return allPages.length;
+    },
     enabled: !!categoryId,
   });
 };

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -5,7 +5,7 @@ import OptionsMenuPortal from '@shared/components/sidebar/OptionsMenuPortal';
 import { useAnchoredMenu } from '@shared/hooks/useAnchoredMenu';
 import { belowOf } from '@shared/utils/anchorPosition';
 import { REMIND_MOCK_DATA } from './constants';
-import { useGetRemindArticles } from './apis/queries';
+import { useGetRemindArticles } from '@pages/remind/apis/queries';
 import { formatLocalDateTime } from '@shared/utils/formatDateTime';
 import NoReadArticles from '@pages/remind/components/noReadArticles/NoReadArticles';
 import NoUnreadArticles from '@pages/remind/components/noUnreadArticles/NoUnreadArticles';

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Badge, PopupContainer } from '@pinback/design-system/ui';
 import CardEditModal from '@shared/components/cardEditModal/CardEditModal';
 import OptionsMenuPortal from '@shared/components/sidebar/OptionsMenuPortal';
@@ -17,12 +17,14 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import NoRemindArticles from './components/noRemindArticles/NoRemindArticles';
 import FetchCard from './components/fetchCard/FetchCard';
+import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
 const Remind = () => {
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [activeBadge, setActiveBadge] = useState<'read' | 'notRead'>('notRead');
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const formattedDate = useMemo(() => {
     return formatLocalDateTime();
@@ -34,12 +36,16 @@ const Remind = () => {
     useGetArticleDetail();
   const { mutate: updateToReadStatus } = usePutArticleReadStatus();
   const { mutate: deleteArticle } = useDeleteRemindArticle();
-  const { data, isPending } = useGetRemindArticles(
+  const { data, isPending, fetchNextPage, hasNextPage } = useGetRemindArticles(
     formattedDate,
-    activeBadge === 'read',
-    0,
-    10
+    activeBadge === 'read'
   );
+
+  const observerRef = useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    root: scrollContainerRef,
+  });
 
   const {
     state: menu,
@@ -48,6 +54,8 @@ const Remind = () => {
     style,
     containerRef,
   } = useAnchoredMenu((anchor) => belowOf(anchor, 8));
+
+  const articlesToDisplay = data?.pages.flatMap((page) => page.articles) ?? [];
 
   const getItemTitle = (id: number | null) =>
     id == null ? '' : (REMIND_MOCK_DATA.find((d) => d.id === id)?.title ?? '');
@@ -73,7 +81,11 @@ const Remind = () => {
   };
 
   const EmptyStateComponent = () => {
-    if (data?.readArticleCount === 0 && data?.unreadArticleCount === 0) {
+    const firstPageData = data?.pages[0];
+    if (
+      firstPageData?.readArticleCount === 0 &&
+      firstPageData?.unreadArticleCount === 0
+    ) {
       return <NoRemindArticles />;
     }
 
@@ -85,27 +97,33 @@ const Remind = () => {
     return <div>Loading...</div>;
   }
 
+  const unreadArticleCount = data?.pages[0]?.unreadArticleCount || 0;
+  const readArticleCount = data?.pages[0]?.readArticleCount || 0;
+
   return (
     <div className="flex flex-col py-[5.2rem] pl-[8rem] pr-[5rem]">
       <p className="head3">리마인드</p>
       <div className="mt-[3rem] flex gap-[2.4rem]">
         <Badge
           text="안 읽음"
-          countNum={data?.unreadArticleCount || 0}
+          countNum={unreadArticleCount}
           onClick={() => handleBadgeClick('notRead')}
           isActive={activeBadge === 'notRead'}
         />
         <Badge
           text="읽음"
-          countNum={data?.readArticleCount || 0}
+          countNum={readArticleCount}
           onClick={() => handleBadgeClick('read')}
           isActive={activeBadge === 'read'}
         />
       </div>
 
-      {data?.articles && data.articles.length > 0 ? (
-        <div className="scrollbar-hide mt-[2.6rem] flex flex-wrap gap-[1.6rem] overflow-y-auto scroll-smooth">
-          {data.articles.map((article) => (
+      {articlesToDisplay.length > 0 ? (
+        <div
+          ref={scrollContainerRef}
+          className="scrollbar-hide mt-[2.6rem] flex flex-wrap gap-[1.6rem] overflow-y-auto scroll-smooth"
+        >
+          {articlesToDisplay.map((article) => (
             <FetchCard
               key={article.articleId}
               article={article}
@@ -132,6 +150,7 @@ const Remind = () => {
               }}
             />
           ))}
+          <div ref={observerRef} style={{ height: '1px', width: '100%' }} />
         </div>
       ) : (
         <EmptyStateComponent />

--- a/apps/client/src/pages/remind/apis/queries.ts
+++ b/apps/client/src/pages/remind/apis/queries.ts
@@ -1,16 +1,17 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getRemindArticles } from './axios';
-import { ArticleListResponse } from '@pages/remind/types/api';
 
-export const useGetRemindArticles = (
-  nowDate: string,
-  readStatus: boolean,
-  page: number,
-  size: number
-): UseQueryResult<ArticleListResponse, AxiosError> => {
-  return useQuery({
-    queryKey: ['remindArticles', nowDate, readStatus, page, size],
-    queryFn: () => getRemindArticles(nowDate, readStatus, page, size),
+export const useGetRemindArticles = (nowDate: string, readStatus: boolean) => {
+  return useInfiniteQuery({
+    queryKey: ['remindArticles', nowDate, readStatus],
+    queryFn: ({ pageParam = 0 }) =>
+      getRemindArticles(nowDate, readStatus, pageParam, 20),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.articles.length === 0) {
+        return undefined;
+      }
+      return allPages.length;
+    },
   });
 };

--- a/apps/client/src/shared/hooks/useInfiniteScroll.ts
+++ b/apps/client/src/shared/hooks/useInfiniteScroll.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+interface UseInfiniteScrollProps {
+  fetchNextPage: () => void;
+  hasNextPage?: boolean;
+  root?: React.RefObject<HTMLElement | null>;
+  threshold?: number;
+}
+
+/**
+ * Intersection Observer를 사용하여 무한 스크롤을 구현하는 커스텀 훅
+ * @returns observer가 감지할 엘리먼트에 연결할 ref 객체
+ */
+
+export const useInfiniteScroll = ({
+  fetchNextPage,
+  hasNextPage,
+  root,
+  threshold = 0.5,
+}: UseInfiniteScrollProps) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: root?.current,
+        threshold,
+      }
+    );
+
+    const currentTarget = targetRef.current;
+    if (currentTarget) {
+      observer.observe(currentTarget);
+    }
+
+    return () => {
+      if (currentTarget) {
+        observer.unobserve(currentTarget);
+      }
+    };
+  }, [fetchNextPage, hasNextPage, root, threshold]);
+
+  return targetRef;
+};


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #157 

## 📄 Tasks
- article intersection observer로 infinite scroll 구현

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->

## ⭐ PR Point (To Reviewer)
`intersection observer`를 이용해서 무한 스크롤 추가했습니다.
remind와 mybookmark 페이지에서 재사용돼서 `useInfiniteScroll.ts`에 커스텀 훅으로 분리했어요.

저희 필터링이 다 다른 API로 분리되어 있어서 `data`나 `fetchNextPage`같은 상태 분기 처리를 하다보니 코드가 너무 지저분하고 복잡하네요...
차라리 이 `badge` 값에 따른 분기 처리 관련 로직을 커스텀 훅으로 분리해서 역할 분리를 해주는 것이 더 좋을 것 같다는 생각도 들어서 리팩토링 할 때 다시 고쳐볼게요.

그리고 지금 `useInfiniteScroll` 훅이 `intersection observer`와 무한 스크롤의 기능을 모두 합친 훅이어서 재사용을 할 때 조금 활용도가 떨어질 수 있을 것이라고 생각해요. 아예 `toss simplekit`에 있는 `useIntersectionObserver`처럼 observer 관련 훅을 추상화하고, infinite scroll은 사용하는 곳에서 정의하도록 하는 것은 어떨까 생각이 드는데 팀원 분들은 어떻게 생각하시나요??
[toss simplekit](https://github.com/toss/react-simplikit/tree/main/src/hooks/useIntersectionObserver)


<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

https://github.com/user-attachments/assets/06b46b47-09cd-4368-a52f-b9c60caa326f




<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 북마크 및 리마인드 화면에 무한 스크롤 도입: 스크롤 시 자동으로 다음 페이지를 불러와 끊김 없이 콘텐츠를 이어봅니다.
  - 페이징 기반 로딩으로 대규모 목록 처리 개선 및 관찰자(센티널)로 자동 추가 로드 구현.
  - 공용 무한스크롤 훅 추가로 관찰/로딩 로직 일관화.
- 버그 수정
  - 빈 상태 표시를 상황(전체/안 읽음)에 맞게 분리 개선.
  - 배지 카운트와 목록 갱신 로직을 페이지 기반 총계로 정확히 반영하도록 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->