### PR TITLE
Fix(client): 리마인드 시간 24시간 내에서만 카드 뜨도록 수정

### DIFF
--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -55,7 +55,18 @@ const Remind = () => {
     containerRef,
   } = useAnchoredMenu((anchor) => belowOf(anchor, 8));
 
-  const articlesToDisplay = data?.pages.flatMap((page) => page.articles) ?? [];
+  // const articlesToDisplay = data?.pages.flatMap((page) => page.articles) ?? [];
+
+  const articlesToDisplay =
+    data?.pages
+      .flatMap((page) => page.articles)
+      .filter((article) => {
+        const now = new Date().getTime();
+        const remindTime = new Date(article.remindAt).getTime();
+        const displayTimeLimit = 24 * 60 * 60 * 1000;
+
+        return remindTime > now && remindTime <= now + displayTimeLimit;
+      }) ?? [];
 
   const getItemTitle = (id: number | null) =>
     id == null ? '' : (REMIND_MOCK_DATA.find((d) => d.id === id)?.title ?? '');

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import NoRemindArticles from './components/noRemindArticles/NoRemindArticles';
 import FetchCard from './components/fetchCard/FetchCard';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
+import { Icon } from '@pinback/design-system/icons';
 
 const Remind = () => {
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -108,8 +109,9 @@ const Remind = () => {
     return <div>Loading...</div>;
   }
 
-  const unreadArticleCount = data?.pages[0]?.unreadArticleCount || 0;
-  const readArticleCount = data?.pages[0]?.readArticleCount || 0;
+  // TODO: 임시
+  // const unreadArticleCount = data?.pages[0]?.unreadArticleCount || 0;
+  // const readArticleCount = data?.pages[0]?.readArticleCount || 0;
 
   return (
     <div className="flex flex-col py-[5.2rem] pl-[8rem] pr-[5rem]">
@@ -117,15 +119,25 @@ const Remind = () => {
       <div className="mt-[3rem] flex gap-[2.4rem]">
         <Badge
           text="안 읽음"
-          countNum={unreadArticleCount}
+          // countNum={unreadArticleCount}
           onClick={() => handleBadgeClick('notRead')}
           isActive={activeBadge === 'notRead'}
+          leftIcon={
+            <Icon
+              name="ic_clock_disable"
+              width={20}
+              height={20}
+              color="gray600"
+              fill="gray600"
+            />
+          }
         />
         <Badge
           text="읽음"
-          countNum={readArticleCount}
+          // countNum={readArticleCount}
           onClick={() => handleBadgeClick('read')}
           isActive={activeBadge === 'read'}
+          leftIcon={<Icon name="ic_clock_active" width={20} height={20} />}
         />
       </div>
 

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -18,7 +18,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import NoRemindArticles from './components/noRemindArticles/NoRemindArticles';
 import FetchCard from './components/fetchCard/FetchCard';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
-import { Icon } from '@pinback/design-system/icons';
 
 const Remind = () => {
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -122,22 +121,12 @@ const Remind = () => {
           // countNum={unreadArticleCount}
           onClick={() => handleBadgeClick('notRead')}
           isActive={activeBadge === 'notRead'}
-          leftIcon={
-            <Icon
-              name="ic_clock_disable"
-              width={20}
-              height={20}
-              color="gray600"
-              fill="gray600"
-            />
-          }
         />
         <Badge
           text="읽음"
           // countNum={readArticleCount}
           onClick={() => handleBadgeClick('read')}
           isActive={activeBadge === 'read'}
-          leftIcon={<Icon name="ic_clock_active" width={20} height={20} />}
         />
       </div>
 

--- a/packages/design-system/src/components/badge/Badge.tsx
+++ b/packages/design-system/src/components/badge/Badge.tsx
@@ -1,8 +1,10 @@
+import { Icon } from '@/icons';
 import { cva } from 'class-variance-authority';
 export interface BadgeProps {
   text: string;
   countNum?: number;
   isActive: boolean;
+  leftIcon?: React.ReactNode;
   onClick?: () => void;
 }
 
@@ -33,18 +35,21 @@ const BadgeStyleVariants = cva(
   }
 );
 
-const Badge = ({ text, countNum, isActive, onClick }: BadgeProps) => {
+const Badge = ({ text, countNum, isActive, onClick, leftIcon }: BadgeProps) => {
   return (
     <div
       className="flex cursor-pointer items-center justify-center gap-[0.8rem]"
       onClick={onClick}
     >
+      {leftIcon}
       <span className={BadgeTxtStyleVariants({ active: isActive })}>
         {text}
       </span>
-      <span className={BadgeStyleVariants({ active: isActive })}>
-        {countNum}
-      </span>
+      {countNum && (
+        <span className={BadgeStyleVariants({ active: isActive })}>
+          {countNum}
+        </span>
+      )}
     </div>
   );
 };

--- a/packages/design-system/src/components/badge/Badge.tsx
+++ b/packages/design-system/src/components/badge/Badge.tsx
@@ -1,10 +1,8 @@
-import { Icon } from '@/icons';
 import { cva } from 'class-variance-authority';
 export interface BadgeProps {
   text: string;
   countNum?: number;
   isActive: boolean;
-  leftIcon?: React.ReactNode;
   onClick?: () => void;
 }
 
@@ -35,17 +33,17 @@ const BadgeStyleVariants = cva(
   }
 );
 
-const Badge = ({ text, countNum, isActive, onClick, leftIcon }: BadgeProps) => {
+const Badge = ({ text, countNum, isActive, onClick }: BadgeProps) => {
   return (
     <div
       className="flex cursor-pointer items-center justify-center gap-[0.8rem]"
       onClick={onClick}
     >
-      {leftIcon}
       <span className={BadgeTxtStyleVariants({ active: isActive })}>
         {text}
       </span>
-      {countNum && (
+
+      {typeof countNum === 'number' && countNum >= 0 && (
         <span className={BadgeStyleVariants({ active: isActive })}>
           {countNum}
         </span>

--- a/packages/design-system/src/components/card/RemindCard.tsx
+++ b/packages/design-system/src/components/card/RemindCard.tsx
@@ -28,7 +28,8 @@ const RemindCard = ({
   const [displayTime, setDisplayTime] = useState('');
 
   useEffect(() => {
-    const endTime = new Date(timeRemaining).getTime() + 24 * 60 * 60 * 1000;
+    // const endTime = new Date(timeRemaining).getTime() + 24 * 60 * 60 * 1000;
+    const endTime = new Date(timeRemaining).getTime();
 
     const updateRemainingTime = () => {
       const now = new Date().getTime();


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #169

## 📄 Tasks
리마인드 시간 24시간 내에서만 remind card ui가 뜨도록 로직 수정했습니다.

## ⭐ PR Point (To Reviewer)
```tsx
const articlesToDisplay =
  data?.pages
    .flatMap((page) => page.articles)
    .filter((article) => {
      const now = new Date().getTime();
      const remindTime = new Date(article.remindAt).getTime();
      const displayTimeLimit = 24 * 60 * 60 * 1000;

      return remindTime > now && remindTime <= now + displayTimeLimit;
    }) ?? [];
```

기존에 card 내부에 있던 로직을 `map` 메서드 사용하는 `remind` 페이지로 올렸습니다.


<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->


<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 리마인드 목록이 이제 향후 24시간 이내 일정만 표시하여 지난 항목과 장기 일정은 제외됩니다.
  - 카드의 남은 시간 계산에서 불필요한 +24시간 보정을 제거해 실제 남은 시간을 기준으로 카운트다운됩니다.
- New Features
  - 배지에 왼쪽 아이콘 지원이 추가되어 상태별 아이콘(예: 시계 활성/비활성)이 표시됩니다.
  - 배지의 숫자는 0일 경우 숨겨지도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->