### PR TITLE
!HOTFIX(client): 리마인드 카드 시간 로직 변경

### DIFF
--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -56,17 +56,16 @@ const Remind = () => {
     containerRef,
   } = useAnchoredMenu((anchor) => belowOf(anchor, 8));
 
-  // const articlesToDisplay = data?.pages.flatMap((page) => page.articles) ?? [];
-
   const articlesToDisplay =
     data?.pages
       .flatMap((page) => page.articles)
       .filter((article) => {
         const now = new Date().getTime();
         const remindTime = new Date(article.remindAt).getTime();
-        const displayTimeLimit = 24 * 60 * 60 * 1000;
+        // 만료 시간 = 리마인드 시간 + 24시간
+        const expirationTime = remindTime + 24 * 60 * 60 * 1000;
 
-        return remindTime > now && remindTime <= now + displayTimeLimit;
+        return now >= remindTime && now < expirationTime;
       }) ?? [];
 
   const getItemTitle = (id: number | null) =>

--- a/apps/client/src/shared/apis/setting/axiosInstance.ts
+++ b/apps/client/src/shared/apis/setting/axiosInstance.ts
@@ -45,7 +45,6 @@ apiRequest.interceptors.request.use(async (config) => {
       } catch (err) {
         console.error('요청 인터셉터에서 토큰 재발급 실패:', err);
         localStorage.removeItem('token');
-        localStorage.removeItem('email');
         window.location.href = '/onboarding';
         throw err;
       }
@@ -95,7 +94,6 @@ apiRequest.interceptors.response.use(
       } catch (refreshError) {
         console.error('토큰 재발급 실패:', refreshError);
         localStorage.removeItem('token');
-        localStorage.removeItem('email');
         window.location.href = '/onboarding';
       }
     }

--- a/apps/client/src/shared/components/cardEditModal/CardEditModal.tsx
+++ b/apps/client/src/shared/components/cardEditModal/CardEditModal.tsx
@@ -244,7 +244,12 @@ export default function CardEditModal({
           {timeError && <p className="body3-r text-error">{timeError}</p>}
         </section>
         {/* TODO: onClick 추후  저장 api 연결후 실패/성공 연결 */}
-        <Button onClick={saveData}>저장하기</Button>
+        <Button
+          onClick={saveData}
+          disabled={!!dateError || !!timeError || isPopError}
+        >
+          저장하기
+        </Button>
       </div>
       {toastIsOpen && (
         <div className="absolute bottom-[2.4rem] left-1/2 -translate-x-1/2">

--- a/apps/extension/src/apis/axiosInstance.ts
+++ b/apps/extension/src/apis/axiosInstance.ts
@@ -44,7 +44,6 @@ apiRequest.interceptors.request.use(async (config) => {
       } catch (err) {
         console.error('요청 인터셉터에서 토큰 재발급 실패:', err);
         localStorage.removeItem('token');
-        localStorage.removeItem('email');
         window.location.href = '/onboarding';
         throw err;
       }

--- a/apps/extension/src/pages/MainPop.tsx
+++ b/apps/extension/src/pages/MainPop.tsx
@@ -359,7 +359,11 @@ const MainPop = ({ type, savedData }: MainPopProps) => {
             ) : null}
           </div>
 
-          <Button size="medium" onClick={handleSave}>
+          <Button
+            size="medium"
+            onClick={handleSave}
+            disabled={isPopError || !!dateError || !!timeError}
+          >
             저장
           </Button>
         </div>

--- a/packages/design-system/src/components/card/RemindCard.tsx
+++ b/packages/design-system/src/components/card/RemindCard.tsx
@@ -28,8 +28,7 @@ const RemindCard = ({
   const [displayTime, setDisplayTime] = useState('');
 
   useEffect(() => {
-    // const endTime = new Date(timeRemaining).getTime() + 24 * 60 * 60 * 1000;
-    const endTime = new Date(timeRemaining).getTime();
+    const endTime = new Date(timeRemaining).getTime() + 24 * 60 * 60 * 1000;
 
     const updateRemainingTime = () => {
       const now = new Date().getTime();


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #175 

## 📄 Tasks
- 리마인드 카드 시간 로직 변경
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->

## ⭐ PR Point (To Reviewer)
기획과 개발팀 싱크가 안맞아서 로직 변경했습니다.

### AS-IS
`카드 남은 시간 = 리마인드 설정 시간 - 현재 시간
`
### TO-BE
`카드 남은 시간 = 리마인드 시간으로부터 남은 24시간 표시
`
크게 많이 바뀐 것은 없습니다! 약간씩만 바꾸면 가능해서 HOTFIX로 수정했습니다.

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot
<img width="938" height="590" alt="image" src="https://github.com/user-attachments/assets/9b1d0858-b514-4438-8828-a7bc08dd4b4a" />


<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 리마인드 글 노출 기간을 “리마인드 시간부터 24시간 동안”으로 정확히 적용하여 조기/지연 노출을 방지했습니다.
  - 리마인드 카드의 남은 시간 계산을 새 24시간 기준에 맞춰 정확히 표시합니다.
- Chores
  - 토큰 갱신 실패 시 저장된 이메일을 더 이상 삭제하지 않아, 웹과 확장 프로그램에서 온보딩으로 이동하더라도 이메일이 유지되어 재로그인이 편리해졌습니다. 토큰만 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->