### PR TITLE
feat: 온보딩 스텝 별 Gtag 추가

### DIFF
--- a/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
@@ -1,4 +1,4 @@
-import { Progress, Button } from '@pinback/design-system/ui';
+import { Progress, Button, sendGAEvent } from '@pinback/design-system/ui';
 import { useState, useEffect, lazy, Suspense } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import SocialLoginStep from './step/SocialLoginStep';
@@ -185,6 +185,11 @@ const MainCard = () => {
     setDirection(1);
     setStep(next);
     navigate(`/onboarding?step=${next}`);
+    sendGAEvent(
+      `onboard-step-${idx + 1}`,
+      `onboard-step-${idx + 1}`,
+      `onboard-step-${idx + 1}`
+    );
   };
 
   const prevStep = () => {

--- a/apps/client/src/pages/onBoarding/components/funnel/step/AlarmStep.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/step/AlarmStep.tsx
@@ -1,10 +1,19 @@
 import dotori from '/assets/onBoarding/icons/dotori.svg';
 import AlarmBox from '../AlarmBox';
+import { useEffect } from 'react';
+import { sendGAEvent } from '@pinback/design-system/ui';
 interface AlarmStepProps {
   selected: 1 | 2 | 3;
   setSelected: (n: 1 | 2 | 3) => void;
 }
 const AlarmStep = ({ selected, setSelected }: AlarmStepProps) => {
+  useEffect(() => {
+    sendGAEvent(
+      'onboard-alarm-step',
+      'onboard-alarm-step',
+      'onboard-alarm-step'
+    );
+  }, []);
   return (
     <div className="flex flex-col items-center justify-between">
       <img src={dotori} className="mb-[1.2rem]" alt="dotori" />

--- a/apps/client/src/pages/onBoarding/components/funnel/step/SocialLoginStep.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/step/SocialLoginStep.tsx
@@ -3,8 +3,16 @@ import GoogleLogo from '/assets/onBoarding/icons/googleLogo.svg';
 import { Link } from 'react-router-dom';
 import { handleGoogleLogin } from '@shared/utils/handleGoogleLogin';
 import { ROUTES_CONFIG } from '@routes/routesConfig';
-
+import { useEffect } from 'react';
+import { sendGAEvent } from '@pinback/design-system/ui';
 const SocialLoginStep = () => {
+  useEffect(() => {
+    sendGAEvent(
+      'onboard-social-login-step',
+      'onboard-social-login-step',
+      'onboard-social-login-step'
+    );
+  }, []);
   return (
     <div className="flex h-full flex-col items-center justify-center">
       <img


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #259

## 📄 Tasks
온보딩 스텝별 Gtag 추가했습니다!

## ⭐ PR Point (To Reviewer)
기획자 로그 네이밍 혼돈을 막기 위해, gtag 네임, 페이지 네임 등을 모두 통일하였습니다.
1. 온보딩 스토리 부분: onboard-step1 ~ step3
2. 소셜 로그인: onboard-social-login-step
3. 알람 스텝: onboard-alarm-step

## 📷 Screenshot
<img width="778" height="998" alt="image" src="https://github.com/user-attachments/assets/42ac331b-0e1b-439d-9cb2-37b8bc02efa2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 온보딩 단계별 사용자 행동 추적 기능 강화: 단계 진행 시 및 알람 설정, 소셜 로그인 단계 진입 시 분석 이벤트 추가로 온보딩 과정의 데이터 수집 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->