### PR TITLE
Setting(project): apps dev 서버 고정 port 지정 및 script 추가

### DIFF
--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
       },
     },
   },
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
 
   resolve: {
     alias: {

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -28,4 +28,9 @@ export default defineConfig({
     copyPublicDir: true,
   },
   publicDir: 'public',
+
+  server: {
+    port: 5175,
+    strictPort: true,
+  },
 });

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -17,4 +17,8 @@ export default defineConfig({
       inject: 'body-last',
     }),
   ],
+  server: {
+    port: 5174,
+    strictPort: true,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "dev:client": "turbo run dev --filter=@pinback/client",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #268 

## 📄 Tasks
- apps dev 서버 고정 port 지정 및 script 추가

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->

## ⭐ PR Point (To Reviewer)
서버 환경 변수 설정으로 구글 소셜 로그인으로 redirect uri로 prod 버전과 localhost 5173 port를 지정해둔 상태예요.
따라서 개발할 대는 5173 port를 사용해야 로그인을 할 수 있는데, 모노레포 구조상 apps 하위 3개의 앱이 모두 매번 랜덤으로 포트가 열리는 상화이였어요.

로그인은 `apps/client`에서 사용하는데 5173 port가 아니면 매번 dev 서버를 다시 열어야 하는 불편함이 있었기에 이를 `client`에는 5173 port가 되도록, 이외 `landing/extension`도 5174/5175 port로 아예 고정을 했어요.

따라서 앞으로 개발할때는 이를 신경쓰지 않아도 괜찮아요. 추가로 앞으로 할 대부분의 개발은 `apps/client`의 비중이 높을텐데 이를 위해
```json
"dev:client": "turbo run dev --filter=@pinback/client",
```
와 같은 script를 root에 추가했으니 필요에 따라 `pnpm dev`가 아닌 `pnpm dev:client`를 통해 개발을 진행하셔도 될 것 같아요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 서버 포트 구성을 업데이트했습니다. 클라이언트, 확장프로그램, 랜딩 페이지가 각각 별도의 포트에서 실행되도록 설정되었습니다.
  * 클라이언트 개발 환경용 새로운 개발 스크립트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->