### PR TITLE
Feat(client): 사이드바에 hasJob 데이터 가져오기 및 가이드 조건 수정

### DIFF
--- a/apps/client/src/shared/components/sidebar/Sidebar.tsx
+++ b/apps/client/src/shared/components/sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ export function Sidebar() {
   const jobPinRef = useRef<HTMLDivElement | null>(null);
   const [guideOpen, setGuideOpen] = useState(false);
 
-  const { data: hasJobData, isLoading: isHasJobLoading } = useGetHasJob(false);
+  const { data: hasJobData } = useGetHasJob(false);
   const { data: categories } = useGetDashboardCategories();
   const { data, isPending: isAcornPending } = useGetAcorns();
   const { data: googleProfileData } = useGetGoogleProfile();
@@ -92,10 +92,10 @@ export function Sidebar() {
   useEffect(() => {
     const guideClosed = localStorage.getItem('jobPinGuideClosed') === 'true';
 
-    if (!isHasJobLoading && hasJobData?.hasJob && !guideClosed) {
+    if (hasJobData?.hasJob && !guideClosed) {
       setGuideOpen(true);
     }
-  }, [hasJobData, isHasJobLoading]);
+  }, [hasJobData]);
 
   const acornCount = data?.acornCount ?? 0;
 


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #295

## 📄 Tasks

+ hasJob 판단 로직을 localStorage에서 API 기반으로 변경
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->

## ⭐ PR Point (To Reviewer)

기존에는

1. localStorage.hasJob 값 확인
2. jobPinGuideClosed 확인
3. 조건 만족하면 말풍선 표시

이렇게 판단하고 있었어요.
다만 localStorage 기반에서 API 방식으로 변경되면서 로직도 함께 수정하게 되었습니다.

지금은

1. Layout에서 hasJob API 호출
2. React Query 캐시에 hasJob 데이터 저장
3. Sidebar에서는 useGetHasJob(false)로 캐시 데이터만 사용하여 판단

하는 구조로 변경했습니다.

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사이드바의 JobPin 가이드 표시 로직을 데이터 기반으로 개선했습니다.
  * 기존 로컬 저장소 기반 체크를 제거해 가이드 표시 상태가 더 안정적으로 동작합니다.

* **스타일**
  * JobPin 영역의 레이아웃 간격과 애니메이션 표시를 소폭 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->