### PR TITLE
Fix:  BaseCard height 조절

### DIFF
--- a/packages/design-system/src/components/card/MyBookmarkCard.tsx
+++ b/packages/design-system/src/components/card/MyBookmarkCard.tsx
@@ -33,7 +33,7 @@ const MyBookmarkCard = ({
     nickname && nickname.trim().length > 0 ? nickname : '도토리';
 
   return (
-    <BaseCard onClick={onClick} className="h-[33.8rem]">
+    <BaseCard onClick={onClick} className="h-auto">
       <div className="flex h-[12rem] w-full items-center justify-center overflow-hidden bg-[#F8F8FA]">
         {imageUrl ? (
           <img src={imageUrl} className="h-full w-full object-cover" />


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #313

## 📄 Tasks
<img width="374" height="496" alt="image" src="https://github.com/user-attachments/assets/f3e6a85c-e02e-4367-bdb4-f32549b31d7e" />

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->
* 북마크의 카드 컴포넌트에서 높이값이 다 다른 것을 확인하고, 북마크 카드 컴포넌트에 있던 height 고정값을 auto로 변경하였습니다.


## ⭐ PR Point (To Reviewer)

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 북마크 카드의 높이가 고정값에서 자동 조정으로 변경되었습니다. 카드가 콘텐츠 크기에 맞게 유연하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->