### PR TITLE
Refactor:  isRefreshing + Queue 패턴 적용

### DIFF
--- a/apps/client/src/shared/apis/setting/axiosInstance.ts
+++ b/apps/client/src/shared/apis/setting/axiosInstance.ts
@@ -85,6 +85,9 @@ apiRequest.interceptors.response.use(
         return new Promise((resolve, reject) => {
           addRefreshSubscriber((token) => {
             if (token) {
+              originalRequest._retry = true;
+              originalRequest.headers = originalRequest.headers ?? {};
+
               originalRequest.headers.Authorization = `Bearer ${token}`;
               resolve(apiRequest(originalRequest));
             } else {


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #317

## 📄 Tasks

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. (없을 경우 section 삭제) -->
*  isRefreshing + Queue 패턴 적용

## ⭐ PR Point (To Reviewer)
```
(error.response.status === 401 || error.response.status === 403)
```
에러 처리가 단순히 조건식으로 되어 있었어요. 그래서 401 등의 에러가 다수 나타날경우 모두 refresh 하게 될거라 예상되어 한번만 refresh 하도록 변경이 필요했습니다
## 해결책 1: refreshPromise 방식 (Promise 공유)

**비동기 작업 자체를 전역 변수에 저장하여 여러 요청이 하나의 응답을 기다리게 만들기**

### 동작 원리

- 첫 번째 401 에러가 발생하면 토큰 재발급 API를 호출하고, 반환한 Promise 객체를 refreshPromise 변수에 담아둔다
- 두 번째 401 에러부터는 refreshPromise 변수가 비어있지 않음을 확인하고, 새로운 API를 호출하는 대신 기존 Promise 객체에 await를 걸어 완료를 기다린다
- 재발급이 끝나면 새 토큰을 챙겨 원래 요청을 다시 보냅니다. 

## 해결책 2: isRefreshing + Queue 패턴 (대기열 방식)

**토큰을 재발급하는 동안 들어오는 요청들을 배열에 모아두었다가, 새 토큰을 받으면 한 번에 재요청을 보내기**

### 동작 원리

- isRefreshing이라는 상태 변수와 대기열 역할을 할 refreshSubscribers 배열을 선언
- 첫 번째 401 에러가 발생하면 isRefreshing을 true로 바꾸고 재발급 API를 호출
- 재발급 진행 중에 들어오는 추가 401 에러들은 isRefreshing이 true인 것을 확인하고, 원래 요청을 다시 실행하는 콜백 함수 형태로 배열에 밀어 넣기
- 새 토큰 발급이 끝나면 배열을 순회하며 대기 중인 콜백 함수들에 새 토큰을 전달하고 일괄 실행


##  최종 isRefreshing + Queue 패턴 적용
단순한 웹 페이지를 넘어 익스텐션 토큰 동기화 로직과 복잡한 세션 만료, 리다이렉트 처리를 직접 통제하고 있기에 세밀한 에러 핸들링이 필요하다 판단되었어요. Promise 캐싱 방식보다 **대기열 방식**이 훨씬 안전하고 다루기 쉽다고 생각해  isRefreshing + Queue 패턴으로 적용했습니다.

<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인증 토큰 갱신 중 발생하는 동시성 문제를 해결했습니다.
  * 여러 요청이 동시에 인증 실패할 때 단일 갱신 시도만 실행하고 대기 중인 요청들은 갱신 완료 후 자동으로 재시도되도록 개선했습니다.
  * 토큰 갱신 실패 시 대기 중인 요청들을 취소하고 사용자를 로그인 페이지로 안전하게 리다이렉트하도록 처리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->