### PR TITLE
Feat(project): amplitude event 연결

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
+    "source.fixAll.eslint": "always",
     "source.organizeImports": "always"
   },
   "tailwindCSS.suggestions": true,

--- a/apps/client/public/firebase-messaging-sw.js
+++ b/apps/client/public/firebase-messaging-sw.js
@@ -1,6 +1,25 @@
 /* eslint-env serviceworker */
 /* eslint-disable no-undef */
 
+const AMPLITUDE_API_KEY = 'bb48a29e445e2f350a1d23ad67f38d55';
+
+const trackAmplitudeEvent = (eventType) => {
+  const isProd = self.location.hostname === 'pinback.today';
+  if (!isProd) {
+    console.log('[Analytics] track', eventType);
+    return;
+  }
+
+  fetch('https://api2.amplitude.com/2/httpapi', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: AMPLITUDE_API_KEY,
+      events: [{ device_id: 'serviceworker', event_type: eventType }],
+    }),
+  }).catch((err) => console.warn('[Amplitude] 이벤트 전송 실패', err));
+};
+
 const firebaseConfig = {
   apiKey: 'AIzaSyD3KM0IQ4Ro3Dd2fyAY8fnhE1bQ_NesrBc',
   authDomain: 'pinback-c55de.firebaseapp.com',
@@ -35,6 +54,8 @@ firebase.initializeApp(firebaseConfig);
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
+  trackAmplitudeEvent('Triggered_Reminder');
+
   const url = payload.data?.url || 'https://pinback.today';
   const notificationTitle = payload.notification?.title || 'pinback';
   const notificationOptions = {
@@ -49,6 +70,8 @@ messaging.onBackgroundMessage((payload) => {
 
 self.addEventListener('notificationclick', (event) => {
   const targetUrl = event.notification.data?.url || 'https://pinback.today';
+
+  trackAmplitudeEvent('Clicked_alarm');
 
   fetch(
     `https://www.google-analytics.com/mp/collect?measurement_id=G-847ZNSCC3J&api_secret=1hei57fPTKyGX5Cw73rwgA`,

--- a/apps/client/src/pages/jobPins/JobPins.tsx
+++ b/apps/client/src/pages/jobPins/JobPins.tsx
@@ -7,8 +7,8 @@ import MemoPopup from '@pages/jobPins/components/MemoPopup';
 import { useJobPinsBottomNotice } from '@pages/jobPins/hooks/useJobPinsBottomNotice';
 import Footer from '@pages/myBookmark/components/footer/Footer';
 import { analytics } from '@pinback/analytics';
-import AnalyticsCardWrapper from '@shared/components/analyticsCardWrapper/AnalyticsCardWrapper';
 import { Card } from '@pinback/design-system/ui';
+import AnalyticsCardWrapper from '@shared/components/analyticsCardWrapper/AnalyticsCardWrapper';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
 const JobPins = () => {
@@ -69,7 +69,10 @@ const JobPins = () => {
             const displayImageUrl = article.thumbnailUrl || undefined;
 
             return (
-              <AnalyticsCardWrapper key={article.articleId} bookmarkType="jobpin">
+              <AnalyticsCardWrapper
+                key={article.articleId}
+                bookmarkType="jobpin"
+              >
                 <Card
                   type="bookmark"
                   variant="save"
@@ -82,7 +85,9 @@ const JobPins = () => {
                   onClick={() => {
                     analytics.track('Clicked_Shared_Bookmark', {
                       article_id: String(article.articleId),
-                      category_id: String(article.category.categoryId),
+                      category_id: article.category
+                        ? String(article.category.categoryId)
+                        : undefined,
                     });
                     getJobPinDetail(article.articleId);
                   }}

--- a/apps/client/src/pages/jobPins/JobPins.tsx
+++ b/apps/client/src/pages/jobPins/JobPins.tsx
@@ -6,6 +6,7 @@ import JobPinsBottomNotice from '@pages/jobPins/components/JobPinsBottomNotice';
 import MemoPopup from '@pages/jobPins/components/MemoPopup';
 import { useJobPinsBottomNotice } from '@pages/jobPins/hooks/useJobPinsBottomNotice';
 import Footer from '@pages/myBookmark/components/footer/Footer';
+import { analytics } from '@pinback/analytics';
 import { Card } from '@pinback/design-system/ui';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
@@ -77,7 +78,13 @@ const JobPins = () => {
                 category={article.category?.categoryName}
                 categoryColor={article.category?.categoryColor}
                 nickname={article.ownerName}
-                onClick={() => getJobPinDetail(article.articleId)}
+                onClick={() => {
+                  analytics.track('Clicked_Shared_Bookmark', {
+                    article_id: String(article.articleId),
+                    category_id: String(article.category.categoryId),
+                  });
+                  getJobPinDetail(article.articleId);
+                }}
               />
             );
           })}

--- a/apps/client/src/pages/jobPins/JobPins.tsx
+++ b/apps/client/src/pages/jobPins/JobPins.tsx
@@ -7,6 +7,7 @@ import MemoPopup from '@pages/jobPins/components/MemoPopup';
 import { useJobPinsBottomNotice } from '@pages/jobPins/hooks/useJobPinsBottomNotice';
 import Footer from '@pages/myBookmark/components/footer/Footer';
 import { analytics } from '@pinback/analytics';
+import AnalyticsCardWrapper from '@shared/components/analyticsCardWrapper/AnalyticsCardWrapper';
 import { Card } from '@pinback/design-system/ui';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
 
@@ -68,24 +69,25 @@ const JobPins = () => {
             const displayImageUrl = article.thumbnailUrl || undefined;
 
             return (
-              <Card
-                key={article.articleId}
-                type="bookmark"
-                variant="save"
-                title={displayTitle}
-                imageUrl={displayImageUrl}
-                content={article.memo}
-                category={article.category?.categoryName}
-                categoryColor={article.category?.categoryColor}
-                nickname={article.ownerName}
-                onClick={() => {
-                  analytics.track('Clicked_Shared_Bookmark', {
-                    article_id: String(article.articleId),
-                    category_id: String(article.category.categoryId),
-                  });
-                  getJobPinDetail(article.articleId);
-                }}
-              />
+              <AnalyticsCardWrapper key={article.articleId} bookmarkType="jobpin">
+                <Card
+                  type="bookmark"
+                  variant="save"
+                  title={displayTitle}
+                  imageUrl={displayImageUrl}
+                  content={article.memo}
+                  category={article.category?.categoryName}
+                  categoryColor={article.category?.categoryColor}
+                  nickname={article.ownerName}
+                  onClick={() => {
+                    analytics.track('Clicked_Shared_Bookmark', {
+                      article_id: String(article.articleId),
+                      category_id: String(article.category.categoryId),
+                    });
+                    getJobPinDetail(article.articleId);
+                  }}
+                />
+              </AnalyticsCardWrapper>
             );
           })}
 

--- a/apps/client/src/pages/jobPins/apis/axios.ts
+++ b/apps/client/src/pages/jobPins/apis/axios.ts
@@ -1,4 +1,4 @@
-import { JobPinsResponse } from '@pages/jobPins/types/api';
+import { type JobPinsResponse } from '@pages/jobPins/types/api';
 import apiRequest from '@shared/apis/setting/axiosInstance';
 
 interface ApiResponse<T> {

--- a/apps/client/src/pages/jobPins/apis/queries.ts
+++ b/apps/client/src/pages/jobPins/apis/queries.ts
@@ -1,9 +1,9 @@
-import { JobPinsResponse } from '@pages/jobPins/types/api';
+import { type JobPinsResponse } from '@pages/jobPins/types/api';
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import {
   getJobPinsArticleDetail,
   getJobPinsArticles,
-  JobPinsDetailResponse,
+  type JobPinsDetailResponse,
 } from './axios';
 
 const PAGE_SIZE = 20;

--- a/apps/client/src/pages/level/Level.tsx
+++ b/apps/client/src/pages/level/Level.tsx
@@ -1,5 +1,5 @@
 import LevelScene from '@pages/level/components/LevelScene';
-import { TreeLevel } from '@pages/level/types/treeLevelType';
+import { type TreeLevel } from '@pages/level/types/treeLevelType';
 import { Icon } from '@pinback/design-system/icons';
 import { Badge } from '@pinback/design-system/ui';
 import { cn } from '@pinback/design-system/utils';

--- a/apps/client/src/pages/level/components/LevelInfoCard.tsx
+++ b/apps/client/src/pages/level/components/LevelInfoCard.tsx
@@ -1,4 +1,4 @@
-import { TREE_LEVEL_TABLE, TreeLevel } from '@pages/level/types/treeLevelType';
+import { TREE_LEVEL_TABLE, type TreeLevel } from '@pages/level/types/treeLevelType';
 import { Level } from '@pinback/design-system/ui';
 import { cn } from '@pinback/design-system/utils';
 

--- a/apps/client/src/pages/level/components/LevelScene.tsx
+++ b/apps/client/src/pages/level/components/LevelScene.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@pinback/design-system/utils';
-import { TreeLevel } from '@pages/level/types/treeLevelType';
-import { HTMLAttributes } from 'react';
+import { type TreeLevel } from '@pages/level/types/treeLevelType';
+import { type HTMLAttributes } from 'react';
 
 import chippi_level1 from '../../../assets/Lv.1.webp';
 import chippi_level2 from '../../../assets/Lv.2.webp';

--- a/apps/client/src/pages/myBookmark/MyBookmark.tsx
+++ b/apps/client/src/pages/myBookmark/MyBookmark.tsx
@@ -101,7 +101,6 @@ const MyBookmark = () => {
             onBadgeChange={setActiveBadge}
             updateToReadStatus={updateToReadStatus}
             openMenu={openMenu}
-            queryClient={queryClient}
             scrollContainerRef={scrollContainerRef}
           />
         </ErrorBoundary>

--- a/apps/client/src/pages/myBookmark/apis/axios.ts
+++ b/apps/client/src/pages/myBookmark/apis/axios.ts
@@ -1,7 +1,7 @@
 import {
-  BookmarkArticlesCountResponse,
-  BookmarkArticlesResponse,
-  CategoryBookmarkArticleResponse,
+  type BookmarkArticlesCountResponse,
+  type BookmarkArticlesResponse,
+  type CategoryBookmarkArticleResponse,
 } from '@pages/myBookmark/types/api';
 import apiRequest from '@shared/apis/setting/axiosInstance';
 

--- a/apps/client/src/pages/myBookmark/apis/queries.ts
+++ b/apps/client/src/pages/myBookmark/apis/queries.ts
@@ -3,7 +3,7 @@ import {
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
 } from '@tanstack/react-query';
-import { CategoryBookmarkArticleResponse } from '../types/api';
+import { type CategoryBookmarkArticleResponse } from '../types/api';
 import {
   getBookmarkArticles,
   getBookmarkArticlesCount,

--- a/apps/client/src/pages/myBookmark/components/myBookmarkContent/MyBookmarkContent.tsx
+++ b/apps/client/src/pages/myBookmark/components/myBookmarkContent/MyBookmarkContent.tsx
@@ -1,7 +1,9 @@
 import NoArticles from '@pages/myBookmark/components/NoArticles/NoArticles';
 import NoUnreadArticles from '@pages/myBookmark/components/noUnreadArticles/NoUnreadArticles';
 import { useMyBookmarkContentData } from '@pages/myBookmark/hooks/useMyBookmarkContentData';
+import { analytics } from '@pinback/analytics';
 import { Badge, Card } from '@pinback/design-system/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { MutableRefObject } from 'react';
 
 interface MyBookmarkContentProps {
@@ -11,7 +13,6 @@ interface MyBookmarkContentProps {
   categoryId: string | null;
   updateToReadStatus: (id: number, options?: any) => void;
   openMenu: (id: number, anchor: HTMLElement) => void;
-  queryClient: any;
   scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
 }
 
@@ -22,9 +23,9 @@ const MyBookmarkContent = ({
   categoryId,
   updateToReadStatus,
   openMenu,
-  queryClient,
   scrollContainerRef,
 }: MyBookmarkContentProps) => {
+  const queryClient = useQueryClient();
   const { view, list, counts, pagination } = useMyBookmarkContentData({
     activeBadge,
     category,
@@ -83,6 +84,10 @@ const MyBookmarkContent = ({
               }
               date={new Date(article.createdAt).toLocaleDateString('ko-KR')}
               onClick={() => {
+                analytics.track('Clicked_My_Bookmark', {
+                  article_id: String(article.articleId),
+                  category_id: article.category?.categoryId?.toString(),
+                });
                 window.open(article.url, '_blank');
                 updateToReadStatus(article.articleId, {
                   onSuccess: () => {

--- a/apps/client/src/pages/myBookmark/components/myBookmarkContent/MyBookmarkContent.tsx
+++ b/apps/client/src/pages/myBookmark/components/myBookmarkContent/MyBookmarkContent.tsx
@@ -3,8 +3,9 @@ import NoUnreadArticles from '@pages/myBookmark/components/noUnreadArticles/NoUn
 import { useMyBookmarkContentData } from '@pages/myBookmark/hooks/useMyBookmarkContentData';
 import { analytics } from '@pinback/analytics';
 import { Badge, Card } from '@pinback/design-system/ui';
+import AnalyticsCardWrapper from '@shared/components/analyticsCardWrapper/AnalyticsCardWrapper';
 import { useQueryClient } from '@tanstack/react-query';
-import { MutableRefObject } from 'react';
+import { type MutableRefObject } from 'react';
 
 interface MyBookmarkContentProps {
   activeBadge: 'all' | 'notRead';
@@ -66,54 +67,55 @@ const MyBookmarkContent = ({
           className="scrollbar-hide mt-[2.6rem] flex h-screen flex-wrap content-start gap-[1.6rem] overflow-y-auto scroll-smooth"
         >
           {list.articles.map((article) => (
-            <Card
-              key={article.articleId}
-              type="bookmark"
-              title={article.title || '제목 없음'}
-              imageUrl={article.thumbnailUrl || undefined}
-              content={article.memo ?? undefined}
-              category={
-                view.isCategoryView
-                  ? view.categoryName
-                  : article.category?.categoryName
-              }
-              categoryColor={
-                view.isCategoryView
-                  ? undefined
-                  : article.category?.categoryColor
-              }
-              date={new Date(article.createdAt).toLocaleDateString('ko-KR')}
-              onClick={() => {
-                analytics.track('Clicked_My_Bookmark', {
-                  article_id: String(article.articleId),
-                  category_id: article.category?.categoryId?.toString(),
-                });
-                window.open(article.url, '_blank');
-                updateToReadStatus(article.articleId, {
-                  onSuccess: () => {
-                    queryClient.invalidateQueries({
-                      queryKey: ['bookmarkArticles'],
-                    });
-                    queryClient.invalidateQueries({
-                      queryKey: ['bookmarkArticlesCount'],
-                    });
-                    queryClient.invalidateQueries({
-                      queryKey: ['categoryBookmarkArticlesCount'],
-                    });
-                    queryClient.invalidateQueries({
-                      queryKey: ['categoryBookmarkArticles'],
-                    });
-                  },
-                  onError: (error: any) => {
-                    console.error(error);
-                  },
-                });
-              }}
-              onOptionsClick={(e) => {
-                e.stopPropagation();
-                openMenu(article.articleId, e.currentTarget);
-              }}
-            />
+            <AnalyticsCardWrapper key={article.articleId} bookmarkType="own">
+              <Card
+                type="bookmark"
+                title={article.title || '제목 없음'}
+                imageUrl={article.thumbnailUrl || undefined}
+                content={article.memo ?? undefined}
+                category={
+                  view.isCategoryView
+                    ? view.categoryName
+                    : article.category?.categoryName
+                }
+                categoryColor={
+                  view.isCategoryView
+                    ? undefined
+                    : article.category?.categoryColor
+                }
+                date={new Date(article.createdAt).toLocaleDateString('ko-KR')}
+                onClick={() => {
+                  analytics.track('Clicked_My_Bookmark', {
+                    article_id: String(article.articleId),
+                    category_id: article.category?.categoryId?.toString(),
+                  });
+                  window.open(article.url, '_blank');
+                  updateToReadStatus(article.articleId, {
+                    onSuccess: () => {
+                      queryClient.invalidateQueries({
+                        queryKey: ['bookmarkArticles'],
+                      });
+                      queryClient.invalidateQueries({
+                        queryKey: ['bookmarkArticlesCount'],
+                      });
+                      queryClient.invalidateQueries({
+                        queryKey: ['categoryBookmarkArticlesCount'],
+                      });
+                      queryClient.invalidateQueries({
+                        queryKey: ['categoryBookmarkArticles'],
+                      });
+                    },
+                    onError: (error: any) => {
+                      console.error(error);
+                    },
+                  });
+                }}
+                onOptionsClick={(e) => {
+                  e.stopPropagation();
+                  openMenu(article.articleId, e.currentTarget);
+                }}
+              />
+            </AnalyticsCardWrapper>
           ))}
 
           <div

--- a/apps/client/src/pages/myBookmark/hooks/useMyBookmarkContentData.ts
+++ b/apps/client/src/pages/myBookmark/hooks/useMyBookmarkContentData.ts
@@ -5,7 +5,7 @@ import {
   useGetCategoryBookmarkArticlesCount,
 } from '@pages/myBookmark/apis/queries';
 import { useInfiniteScroll } from '@shared/hooks/useInfiniteScroll';
-import { MutableRefObject } from 'react';
+import { type MutableRefObject } from 'react';
 
 interface UseMyBookmarkContentDataParams {
   activeBadge: 'all' | 'notRead';

--- a/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/MainCard.tsx
@@ -1,6 +1,6 @@
 import {
   Step,
-  StepType,
+  type StepType,
   storySteps,
 } from '@pages/onBoarding/constants/onboardingSteps';
 import { useOnboardingFunnel } from '@pages/onBoarding/hooks/useOnboardingFunnel';

--- a/apps/client/src/pages/onBoarding/components/funnel/step/job/JobStep.tsx
+++ b/apps/client/src/pages/onBoarding/components/funnel/step/job/JobStep.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import dotori from '/assets/onBoarding/icons/dotori.svg';
 import { Checkbox } from '@pinback/design-system/ui';
-import { JobsResponse } from '@shared/types/api';
+import { type JobsResponse } from '@shared/types/api';
 import JobCards from '@shared/components/jobSelectionFunnel/step/job/JobCards';
 import JobCardsSkeleton from '@shared/components/jobSelectionFunnel/step/job/JobCardsSkeleton';
 

--- a/apps/client/src/pages/onBoarding/components/timePicker/TimePicker.tsx
+++ b/apps/client/src/pages/onBoarding/components/timePicker/TimePicker.tsx
@@ -1,10 +1,10 @@
 import {
   Button,
   WheelPicker,
-  WheelPickerOption,
+  type WheelPickerOption,
   WheelPickerWrapper,
 } from '@pinback/design-system/ui';
-import { MouseEventHandler, useState } from 'react';
+import { type MouseEventHandler, useState } from 'react';
 
 const createArray = (length: number, add = 0): WheelPickerOption[] =>
   Array.from({ length }, (_, i) => {

--- a/apps/client/src/pages/onBoarding/hooks/useOnboardingFunnel.ts
+++ b/apps/client/src/pages/onBoarding/hooks/useOnboardingFunnel.ts
@@ -2,7 +2,7 @@ import { AlarmsType } from '@constants/alarms';
 import {
   Step,
   stepOrder,
-  StepType,
+  type StepType,
 } from '@pages/onBoarding/constants/onboardingSteps';
 import { normalizeTime } from '@pages/onBoarding/utils/formatRemindTime';
 import { registerServiceWorker } from '@pages/onBoarding/utils/registerServiceWorker';

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -1,5 +1,6 @@
 import { useGetRemindArticles } from '@pages/remind/apis/queries';
 import { analytics } from '@pinback/analytics';
+import AnalyticsCardWrapper from '@shared/components/analyticsCardWrapper/AnalyticsCardWrapper';
 import NoReadArticles from '@pages/remind/components/noReadArticles/NoReadArticles';
 import NoUnreadArticles from '@pages/remind/components/noUnreadArticles/NoUnreadArticles';
 import {
@@ -152,28 +153,28 @@ const Remind = () => {
             const displayImageUrl = article.thumbnailUrl || undefined;
 
             return (
-              <Card
-                key={article.articleId}
-                type="remind"
-                title={displayTitle}
-                imageUrl={displayImageUrl}
-                content={article.memo}
-                timeRemaining={article.remindAt}
-                category={article.category.categoryName}
-                categoryColor={article.category.categoryColor}
-                onClick={() => {
-                  analytics.track('Clicked_Reminder', {
-                    article_id: String(article.articleId),
-                  });
-                  window.open(article.url, '_blank');
-                  updateToReadStatus(article.articleId);
-                }}
-                onOptionsClick={(e) => {
-                  e.stopPropagation();
-
-                  openMenu(article.articleId, e.currentTarget);
-                }}
-              />
+              <AnalyticsCardWrapper key={article.articleId} bookmarkType="remind">
+                <Card
+                  type="remind"
+                  title={displayTitle}
+                  imageUrl={displayImageUrl}
+                  content={article.memo}
+                  timeRemaining={article.remindAt}
+                  category={article.category.categoryName}
+                  categoryColor={article.category.categoryColor}
+                  onClick={() => {
+                    analytics.track('Clicked_Reminder', {
+                      article_id: String(article.articleId),
+                    });
+                    window.open(article.url, '_blank');
+                    updateToReadStatus(article.articleId);
+                  }}
+                  onOptionsClick={(e) => {
+                    e.stopPropagation();
+                    openMenu(article.articleId, e.currentTarget);
+                  }}
+                />
+              </AnalyticsCardWrapper>
             );
           })}
 

--- a/apps/client/src/pages/remind/Remind.tsx
+++ b/apps/client/src/pages/remind/Remind.tsx
@@ -1,4 +1,5 @@
 import { useGetRemindArticles } from '@pages/remind/apis/queries';
+import { analytics } from '@pinback/analytics';
 import NoReadArticles from '@pages/remind/components/noReadArticles/NoReadArticles';
 import NoUnreadArticles from '@pages/remind/components/noUnreadArticles/NoUnreadArticles';
 import {
@@ -161,6 +162,9 @@ const Remind = () => {
                 category={article.category.categoryName}
                 categoryColor={article.category.categoryColor}
                 onClick={() => {
+                  analytics.track('Clicked_Reminder', {
+                    article_id: String(article.articleId),
+                  });
                   window.open(article.url, '_blank');
                   updateToReadStatus(article.articleId);
                 }}

--- a/apps/client/src/shared/apis/axios.ts
+++ b/apps/client/src/shared/apis/axios.ts
@@ -1,9 +1,9 @@
 import apiRequest from '@shared/apis/setting/axiosInstance';
 import {
-  AmplitudeUserPropertiesResponse,
-  EditArticleRequest,
-  HasJobResponse,
-  JobsResponse,
+  type AmplitudeUserPropertiesResponse,
+  type EditArticleRequest,
+  type HasJobResponse,
+  type JobsResponse,
 } from '@shared/types/api';
 import { formatLocalDateTime } from '@shared/utils/formatDateTime';
 

--- a/apps/client/src/shared/apis/queries.ts
+++ b/apps/client/src/shared/apis/queries.ts
@@ -12,36 +12,36 @@ import {
   getMyProfile,
   patchCategory,
   patchUserJob,
-  patchUserJobRequest,
+  type patchUserJobRequest,
   postCategory,
   postSignUp,
-  postSignUpRequest,
+  type postSignUpRequest,
   putArticleReadStatus,
   putEditArticle,
 } from '@shared/apis/axios';
 import {
-  AcornsResponse,
-  AmplitudeUserPropertiesResponse,
-  ArticleDetailResponse,
-  ArticleReadStatusResponse,
-  CategoryDetailResponse,
-  DashboardCategoriesResponse,
-  EditArticleRequest,
-  HasJobResponse,
-  JobsResponse,
+  type AcornsResponse,
+  type AmplitudeUserPropertiesResponse,
+  type ArticleDetailResponse,
+  type ArticleReadStatusResponse,
+  type CategoryDetailResponse,
+  type DashboardCategoriesResponse,
+  type EditArticleRequest,
+  type HasJobResponse,
+  type JobsResponse,
 } from '@shared/types/api';
 import { fetchOGData } from '@shared/utils/fetchOgData';
 import { authStorage } from '@shared/utils/authStorage';
 import { extensionBridge } from '@shared/utils/extensionBridge';
 import {
   useMutation,
-  UseMutationResult,
+  type UseMutationResult,
   useQuery,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
   useSuspenseQuery,
 } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { type AxiosError } from 'axios';
 
 export const useGetDashboardCategories = (): UseQueryResult<
   DashboardCategoriesResponse,

--- a/apps/client/src/shared/components/analyticsCardWrapper/AnalyticsCardWrapper.tsx
+++ b/apps/client/src/shared/components/analyticsCardWrapper/AnalyticsCardWrapper.tsx
@@ -22,7 +22,7 @@ const AnalyticsCardWrapper = ({
         bookmark_type: bookmarkType,
       });
     }
-  }, [inView]);
+  }, [inView, bookmarkType]);
 
   return <div ref={ref}>{children}</div>;
 };

--- a/apps/client/src/shared/components/analyticsCardWrapper/AnalyticsCardWrapper.tsx
+++ b/apps/client/src/shared/components/analyticsCardWrapper/AnalyticsCardWrapper.tsx
@@ -1,0 +1,30 @@
+import {
+  analytics,
+  type ImpressionSavedContentProperties,
+} from '@pinback/analytics';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+interface AnalyticsCardWrapperProps {
+  bookmarkType: ImpressionSavedContentProperties['bookmark_type'];
+  children: React.ReactNode;
+}
+
+const AnalyticsCardWrapper = ({
+  bookmarkType,
+  children,
+}: AnalyticsCardWrapperProps) => {
+  const { ref, inView } = useInView({ threshold: 0.5, triggerOnce: true });
+
+  useEffect(() => {
+    if (inView) {
+      analytics.track('Impression_Saved_Content', {
+        bookmark_type: bookmarkType,
+      });
+    }
+  }, [inView]);
+
+  return <div ref={ref}>{children}</div>;
+};
+
+export default AnalyticsCardWrapper;

--- a/apps/client/src/shared/components/balloon/Balloon.tsx
+++ b/apps/client/src/shared/components/balloon/Balloon.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@pinback/design-system/icons';
 import { cn } from '@pinback/design-system/utils';
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 type BalloonVariant = 'gray' | 'main';
 

--- a/apps/client/src/shared/components/cardEditModal/CardEditModal.tsx
+++ b/apps/client/src/shared/components/cardEditModal/CardEditModal.tsx
@@ -18,7 +18,7 @@ import {
   useGetDashboardCategories,
   usePutEditArticle,
 } from '@shared/apis/queries';
-import { ArticleDetailResponse, EditArticleRequest } from '@shared/types/api';
+import { type ArticleDetailResponse, type EditArticleRequest } from '@shared/types/api';
 import { combineDateTime } from '@shared/utils/datetime';
 import { updateDate, updateTime } from '@shared/utils/formatDateTime';
 import { useQueryClient } from '@tanstack/react-query';

--- a/apps/client/src/shared/components/jobSelectionFunnel/step/job/JobStep.tsx
+++ b/apps/client/src/shared/components/jobSelectionFunnel/step/job/JobStep.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Checkbox } from '@pinback/design-system/ui';
-import { JobsResponse } from '@shared/types/api';
+import { type JobsResponse } from '@shared/types/api';
 import JobCards from './JobCards';
 import JobCardsSkeleton from './JobCardsSkeleton';
 

--- a/apps/client/src/shared/components/sidebar/AccordionItem.tsx
+++ b/apps/client/src/shared/components/sidebar/AccordionItem.tsx
@@ -1,7 +1,7 @@
 import { useState, useId } from 'react';
 import { cn } from '@pinback/design-system/utils';
 import SideItem from './SideItem';
-import { IconToken } from './types/IconTokenType';
+import { type IconToken } from './types/IconTokenType';
 
 interface AccordionItemProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {

--- a/apps/client/src/shared/components/sidebar/SideItem.tsx
+++ b/apps/client/src/shared/components/sidebar/SideItem.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconName } from '@pinback/design-system/icons';
 import { cn } from '@pinback/design-system/utils';
-import { IconToken } from './types/IconTokenType';
+import { type IconToken } from './types/IconTokenType';
 
 const ICON_MAP: Record<IconToken, { on: IconName; off: IconName }> = {
   clock: { on: 'ic_clock_active', off: 'ic_clock_disable' },

--- a/apps/client/src/shared/components/sidebar/hooks/useCategoryActions.ts
+++ b/apps/client/src/shared/components/sidebar/hooks/useCategoryActions.ts
@@ -4,9 +4,9 @@ import {
   usePatchCategory,
   usePostCategory,
 } from '@shared/apis/queries';
-import { SidebarTab } from '@shared/hooks/useSidebarNav';
+import { type SidebarTab } from '@shared/hooks/useSidebarNav';
 import { useQueryClient } from '@tanstack/react-query';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { type Dispatch, type SetStateAction, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface CategoryActionsParams {

--- a/apps/client/src/shared/utils/fetchOgData.ts
+++ b/apps/client/src/shared/utils/fetchOgData.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 
 export interface OGData {
   title: string;

--- a/apps/client/src/shared/utils/treeLevel.ts
+++ b/apps/client/src/shared/utils/treeLevel.ts
@@ -1,7 +1,7 @@
 import {
   TREE_LEVEL_TABLE,
-  TreeLevelResult,
-  TreeLevelRow,
+  type TreeLevelResult,
+  type TreeLevelRow,
 } from '@pages/level/types/treeLevelType';
 
 function findLevelRow(count: number, rows: readonly TreeLevelRow[]) {

--- a/apps/extension/src/pages/MainPop.tsx
+++ b/apps/extension/src/pages/MainPop.tsx
@@ -23,7 +23,7 @@ import {
   validateDate,
   validateTime,
 } from '@pinback/design-system/ui';
-import { ArticleResponse } from '@shared-types/types';
+import { type ArticleResponse } from '@shared-types/types';
 import Header from '@shared/components/Header';
 import {
   combineDateTime,
@@ -218,7 +218,9 @@ const MainPop = ({ type, savedData }: MainPopProps) => {
               // article_id: 응답 타입 미정의로 보류
               category_id: selected ?? undefined,
               // is_first_save: 판단 불가로 보류
-              page_domain: new URL(url).hostname,
+              page_domain: URL.canParse(url)
+                ? new URL(url).hostname
+                : undefined,
             });
             save({
               url,

--- a/apps/extension/src/pages/MainPop.tsx
+++ b/apps/extension/src/pages/MainPop.tsx
@@ -8,6 +8,7 @@ import thumbImg from '@assets/extension_thumb.svg';
 import { useCategoryManager } from '@hooks/useCategoryManager';
 import { usePageMeta } from '@hooks/usePageMeta';
 import { useSaveBookmark } from '@hooks/useSaveBookmarks';
+import { analytics } from '@pinback/analytics';
 import { Icon } from '@pinback/design-system/icons';
 import {
   AutoDismissToast,
@@ -213,6 +214,12 @@ const MainPop = ({ type, savedData }: MainPopProps) => {
         },
         {
           onSuccess: () => {
+            analytics.track('Saved_Article', {
+              // article_id: 응답 타입 미정의로 보류
+              category_id: selected ?? undefined,
+              // is_first_save: 판단 불가로 보류
+              page_domain: new URL(url).hostname,
+            });
             save({
               url,
               title,

--- a/packages/analytics/index.ts
+++ b/packages/analytics/index.ts
@@ -3,6 +3,7 @@ import { amplitudeProvider } from './src/providers/amplitude';
 import { consoleProvider } from './src/providers/console';
 
 export type { AnalyticsProvider, UserProperties } from './src/types';
+export type * from './src/ampli';
 export { analytics };
 
 interface InitAnalyticsOptions {

--- a/packages/analytics/src/ampli/index.ts
+++ b/packages/analytics/src/ampli/index.ts
@@ -66,6 +66,17 @@ export interface ClickedAlarmProperties {
   reminder_id?: string;
 }
 
+export interface ClickedMyBookmarkProperties {
+  /**
+   * 아티클 고유 ID (특정 아티클 재열람 확인 등)
+   */
+  article_id?: string;
+  /**
+   * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
+   */
+  category_id?: string;
+}
+
 export interface ClickedReminderProperties {
   /**
    * 아티클 고유 ID (특정 아티클 재열람 확인 등)
@@ -171,6 +182,16 @@ export class ClickedAlarm implements BaseEvent {
 
   constructor(
     public event_properties?: ClickedAlarmProperties,
+  ) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class ClickedMyBookmark implements BaseEvent {
+  event_type = 'Clicked_My_Bookmark';
+
+  constructor(
+    public event_properties?: ClickedMyBookmarkProperties,
   ) {
     this.event_properties = event_properties;
   }
@@ -368,6 +389,23 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(new ClickedAlarm(properties), options);
+  }
+
+  /**
+   * Clicked_My_Bookmark
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Clicked_My_Bookmark)
+   *
+   * 대시보드 나의 북마크 카드를 클릭했을 때 발생 (여기서 나의 북마크는 북마크 전체, 카테고리 등 전체를 포함함.)
+   *
+   * @param properties The event's properties (e.g. article_id)
+   * @param options Amplitude event options.
+   */
+  clickedMyBookmark(
+    properties?: ClickedMyBookmarkProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new ClickedMyBookmark(properties), options);
   }
 
   /**

--- a/packages/analytics/src/ampli/index.ts
+++ b/packages/analytics/src/ampli/index.ts
@@ -55,6 +55,17 @@ export interface IdentifyProperties {
   job_role?: string;
 }
 
+export interface ClickedAlarmProperties {
+  /**
+   * 아티클 고유 ID (특정 아티클 재열람 확인 등)
+   */
+  article_id?: string;
+  /**
+   * 리마인드 아이디(보내고 클릭해졌는지 클릭률 계산 등)
+   */
+  reminder_id?: string;
+}
+
 export interface ClickedReminderProperties {
   /**
    * 아티클 고유 ID (특정 아티클 재열람 확인 등)
@@ -64,10 +75,6 @@ export interface ClickedReminderProperties {
    * 리마인드 아이디(보내고 클릭해졌는지 클릭률 계산 등)
    */
   reminder_id?: string;
-  /**
-   * 리마인드 유형
-   */
-  reminder_type?: string;
 }
 
 export interface ClickedSharedBookmarkProperties {
@@ -79,21 +86,6 @@ export interface ClickedSharedBookmarkProperties {
    * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
    */
   category_id?: string;
-}
-
-export interface OpenedSavedContentProperties {
-  /**
-   * 아티클 고유 ID (특정 아티클 재열람 확인 등)
-   */
-  article_id?: string;
-  /**
-   * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
-   */
-  category_id?: string;
-  /**
-   * 콘텐츠 유입 출처
-   */
-  source_type?: string;
 }
 
 export interface SavedArticleProperties {
@@ -113,14 +105,6 @@ export interface SavedArticleProperties {
    * 저장 대상 페이지 도메인
    */
   page_domain?: string;
-  /**
-   * 저장 방식
-   */
-  save_method?: string;
-  /**
-   * 저장이 발생한 위치
-   */
-  save_source?: string;
 }
 
 export interface SavedSharedBookmarkProperties {
@@ -129,17 +113,17 @@ export interface SavedSharedBookmarkProperties {
    */
   article_id?: string;
   /**
+   * 콘텐츠 유입 출처
+   *
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | own, jobpin, remind |
+   */
+  bookmark_type?: "own" | "jobpin" | "remind";
+  /**
    * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
    */
   category_id?: string;
-  /**
-   * 저장이 발생한 위치
-   */
-  save_source?: string;
-  /**
-   * 콘텐츠 유입 출처
-   */
-  source_type?: string;
 }
 
 export interface TriggeredReminderProperties {
@@ -151,10 +135,6 @@ export interface TriggeredReminderProperties {
    * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
    */
   category_id?: string;
-  /**
-   * 리마인드 유형
-   */
-  reminder_type?: string;
 }
 
 export interface ViewedSavedContentProperties {
@@ -163,13 +143,17 @@ export interface ViewedSavedContentProperties {
    */
   article_id?: string;
   /**
+   * 콘텐츠 유입 출처
+   *
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | own, jobpin, remind |
+   */
+  bookmark_type?: "own" | "jobpin" | "remind";
+  /**
    * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
    */
   category_id?: string;
-  /**
-   * 콘텐츠 유입 출처
-   */
-  source_type?: string;
 }
 
 export class Identify implements BaseEvent {
@@ -177,6 +161,16 @@ export class Identify implements BaseEvent {
 
   constructor(
     public event_properties?: IdentifyProperties,
+  ) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class ClickedAlarm implements BaseEvent {
+  event_type = 'Clicked_alarm';
+
+  constructor(
+    public event_properties?: ClickedAlarmProperties,
   ) {
     this.event_properties = event_properties;
   }
@@ -197,16 +191,6 @@ export class ClickedSharedBookmark implements BaseEvent {
 
   constructor(
     public event_properties?: ClickedSharedBookmarkProperties,
-  ) {
-    this.event_properties = event_properties;
-  }
-}
-
-export class OpenedSavedContent implements BaseEvent {
-  event_type = 'Opened_Saved_Content';
-
-  constructor(
-    public event_properties?: OpenedSavedContentProperties,
   ) {
     this.event_properties = event_properties;
   }
@@ -250,10 +234,6 @@ export class ViewedSavedContent implements BaseEvent {
   ) {
     this.event_properties = event_properties;
   }
-}
-
-export class ViewedSharedBookmarkList implements BaseEvent {
-  event_type = 'Viewed_Shared_Bookmark_List';
 }
 
 export type PromiseResult<T> = { promise: Promise<T | void> };
@@ -374,11 +354,28 @@ export class Ampli {
   }
 
   /**
+   * Clicked_alarm
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Clicked_alarm)
+   *
+   * 알림을 클릭했을 때 발생
+   *
+   * @param properties The event's properties (e.g. article_id)
+   * @param options Amplitude event options.
+   */
+  clickedAlarm(
+    properties?: ClickedAlarmProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new ClickedAlarm(properties), options);
+  }
+
+  /**
    * Clicked_Reminder
    *
    * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Clicked_Reminder)
    *
-   * 사용자가 리마인드를 클릭했을 때 발생
+   * 대시보드 리마인드 카드를 클릭했을 때 발생
    *
    * @param properties The event's properties (e.g. article_id)
    * @param options Amplitude event options.
@@ -405,23 +402,6 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(new ClickedSharedBookmark(properties), options);
-  }
-
-  /**
-   * Opened_Saved_Content
-   *
-   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Opened_Saved_Content)
-   *
-   * 저장한 콘텐츠를 다시 클릭해 열었을 때 발생
-   *
-   * @param properties The event's properties (e.g. article_id)
-   * @param options Amplitude event options.
-   */
-  openedSavedContent(
-    properties?: OpenedSavedContentProperties,
-    options?: EventOptions,
-  ) {
-    return this.track(new OpenedSavedContent(properties), options);
   }
 
   /**
@@ -490,21 +470,6 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(new ViewedSavedContent(properties), options);
-  }
-
-  /**
-   * Viewed_Shared_Bookmark_List
-   *
-   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Viewed_Shared_Bookmark_List)
-   *
-   * 공유 북마크 목록을 조회했을 때 발생
-   *
-   * @param options Amplitude event options.
-   */
-  viewedSharedBookmarkList(
-    options?: EventOptions,
-  ) {
-    return this.track(new ViewedSharedBookmarkList(), options);
   }
 }
 

--- a/packages/analytics/src/ampli/index.ts
+++ b/packages/analytics/src/ampli/index.ts
@@ -99,6 +99,25 @@ export interface ClickedSharedBookmarkProperties {
   category_id?: string;
 }
 
+export interface ImpressionSavedContentProperties {
+  /**
+   * 아티클 고유 ID (특정 아티클 재열람 확인 등)
+   */
+  article_id?: string;
+  /**
+   * 콘텐츠 유입 출처
+   *
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | own, jobpin, remind |
+   */
+  bookmark_type?: "own" | "jobpin" | "remind";
+  /**
+   * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
+   */
+  category_id?: string;
+}
+
 export interface SavedArticleProperties {
   /**
    * 아티클 고유 ID (특정 아티클 재열람 확인 등)
@@ -142,25 +161,6 @@ export interface TriggeredReminderProperties {
    * 아티클 고유 ID (특정 아티클 재열람 확인 등)
    */
   article_id?: string;
-  /**
-   * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
-   */
-  category_id?: string;
-}
-
-export interface ViewedSavedContentProperties {
-  /**
-   * 아티클 고유 ID (특정 아티클 재열람 확인 등)
-   */
-  article_id?: string;
-  /**
-   * 콘텐츠 유입 출처
-   *
-   * | Rule | Value |
-   * |---|---|
-   * | Enum Values | own, jobpin, remind |
-   */
-  bookmark_type?: "own" | "jobpin" | "remind";
   /**
    * 카테고리 고유 ID (어디에 저장됐는지, 공유 여부 확인 등)
    */
@@ -217,6 +217,16 @@ export class ClickedSharedBookmark implements BaseEvent {
   }
 }
 
+export class ImpressionSavedContent implements BaseEvent {
+  event_type = 'Impression_Saved_Content';
+
+  constructor(
+    public event_properties?: ImpressionSavedContentProperties,
+  ) {
+    this.event_properties = event_properties;
+  }
+}
+
 export class SavedArticle implements BaseEvent {
   event_type = 'Saved_Article';
 
@@ -242,16 +252,6 @@ export class TriggeredReminder implements BaseEvent {
 
   constructor(
     public event_properties?: TriggeredReminderProperties,
-  ) {
-    this.event_properties = event_properties;
-  }
-}
-
-export class ViewedSavedContent implements BaseEvent {
-  event_type = 'Viewed_Saved_Content';
-
-  constructor(
-    public event_properties?: ViewedSavedContentProperties,
   ) {
     this.event_properties = event_properties;
   }
@@ -443,6 +443,23 @@ export class Ampli {
   }
 
   /**
+   * Impression_Saved_Content
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Impression_Saved_Content)
+   *
+   * 저장한 콘텐츠 목록 또는 상세가 노출될 때 발생
+   *
+   * @param properties The event's properties (e.g. article_id)
+   * @param options Amplitude event options.
+   */
+  impressionSavedContent(
+    properties?: ImpressionSavedContentProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new ImpressionSavedContent(properties), options);
+  }
+
+  /**
    * Saved_Article
    *
    * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Saved_Article)
@@ -491,23 +508,6 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(new TriggeredReminder(properties), options);
-  }
-
-  /**
-   * Viewed_Saved_Content
-   *
-   * [View in Tracking Plan](https://data.amplitude.com/pinback/default/events/main/latest/Viewed_Saved_Content)
-   *
-   * 저장한 콘텐츠 목록 또는 상세가 노출될 때 발생
-   *
-   * @param properties The event's properties (e.g. article_id)
-   * @param options Amplitude event options.
-   */
-  viewedSavedContent(
-    properties?: ViewedSavedContentProperties,
-    options?: EventOptions,
-  ) {
-    return this.track(new ViewedSavedContent(properties), options);
   }
 }
 

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -34,6 +34,10 @@ const config = [
       ...pluginReactHooks.configs.recommended.rules,
       // React scope no longer necessary with new JSX transform.
       'react/react-in-jsx-scope': 'off',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
     },
   },
 ];


### PR DESCRIPTION
## 📌 Related Issues

> 관련된 Issue를 태그해주세요. (e.g. - close #25)

- close #327 

## 📄 Tasks
- `ampli pull`을 통해 `Viewed_Saved_Content` → `Impression_Saved_Content` 이벤트로 교체                                          
- `@pinback/analytics` 패키지에서 ampli 타입 전체 re-export (`export type *`)
- 카드 뷰포트 노출 트래킹용 공통 컴포넌트 `AnalyticsCardWrapper` 추가                                                            
- `react-intersection-observer`의 `useInView`를 활용해 카드가 뷰포트에 노출될 때 이벤트 발화 (`triggerOnce: true`)             
- Remind, MyBookmark, JobPins 페이지 카드에 `Impression_Saved_Content` 이벤트 연결 (`bookmark_type`으로 탭 구분)                 
- ESLint `consistent-type-imports` 룰 추가 및 저장 시 자동 수정 활성화 

## ⭐ PR Point (To Reviewer)
- `Saved_Shared_Bookmark` 이벤트는 dashboard → 외부 사이트 → extension 저장으로 이어지는 크로스 컨텍스트 구조상 신뢰도 있는 트래킹이 어려워 연결하지 않았습니다.
- `Impression_Saved_Content`의 `article_id`, `category_id` 프로퍼티는 유저별 내부 ID라 cross-user 집계가 불가능하여 현재 미사용 처리하였습니다.
<!-- 리뷰어에게 추가로 전달할 사항이 있다면 작성해주세요. (없을 경우 section 삭제) -->

## 📷 Screenshot

<!-- 작업한 내용에 대한 자료가 필요하다면 첨부해주세요. (없을 경우 section 삭제)-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firebase 알림에 Amplitude 이벤트 전송 추가(백그라운드 알림 발생/클릭 추적)
  * 카드 단위 노출(Impression) 및 클릭 이벤트 수집을 위한 분석 래퍼 도입(북마크·잡핀·리마인더·내북마크)
  * 확장 프로그램의 기사 저장 시 분석 이벤트 전송 추가

* **Refactor**
  * TypeScript 타입 전용(import type) 사용 확대(빌드 최적화)
  * ESLint 자동 수정(on save) 및 타입 임포트 규칙 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->